### PR TITLE
authorization header becomes optional.

### DIFF
--- a/rest_api_spec/onboarding-swagger.yml
+++ b/rest_api_spec/onboarding-swagger.yml
@@ -84,8 +84,10 @@ paths:
         -
           name: authorization
           in: header
-          description: user/ thing access token.
-          required: true
+          description: user/ thing access token. If the onboarding is
+              initiated by Thing, this field can not be contained in the
+              request.
+          required: false
           type: string
         - name: appID
           in: path


### PR DESCRIPTION
From https://sites.google.com/a/kii.com/kii-cloud-docs/home/iot-cloud/2-onboarding, section `Onbording endopoint/Overview/From Thing/Step1 Thing onborading`. I think authorization header is not required.

Is this correct? If correct, please merge this PR.
