### PR TITLE
Add gt202 sample

### DIFF
--- a/gt202/kii_iot_demo.c
+++ b/gt202/kii_iot_demo.c
@@ -10,7 +10,7 @@
 
 const char EX_APP_ID[] = "00959619";
 const char EX_APP_KEY[] = "1ae0bcded44365e4f83c2daa2f4ca237";
-const char EX_APP_SITE[] = "54.65.208.49";/*"api-development-jp.internal.kii.com";*/
+const char EX_APP_SITE[] = "api-development-jp.internal.kii.com";
 
 const char EX_AUTH_VENDOR_ID[] = "464939";
 const char EX_AUTH_VENDOR_PASS[] = "1234";

--- a/gt202/kii_iot_demo.c
+++ b/gt202/kii_iot_demo.c
@@ -1,0 +1,249 @@
+#include "kii_iot_demo.h"
+
+#include <kii_iot.h>
+#include <kii_json.h>
+
+#include <string.h>
+#include <stdio.h>
+
+#include "main.h"
+
+const char EX_APP_ID[] = "00959619";
+const char EX_APP_KEY[] = "1ae0bcded44365e4f83c2daa2f4ca237";
+const char EX_APP_SITE[] = "54.65.208.49";/*"api-development-jp.internal.kii.com";*/
+
+const char EX_AUTH_VENDOR_ID[] = "464939";
+const char EX_AUTH_VENDOR_PASS[] = "1234";
+
+const char EX_AUTH_THING_ID[] = "th.53ae324be5a0-f5e8-5e11-fdd5-000ee263";
+const char EX_ACCESS_TOKEN[] = "7H2sc6UYvC2mKCFihYhA52xh1b--G3rga_OYz_gbCg4";
+
+#define EX_COMMAND_HANDLER_BUFF_SIZE 4096
+#define EX_STATE_UPDATER_BUFF_SIZE 4096
+#define EX_MQTT_BUFF_SIZE 2048
+#define EX_STATE_UPDATE_PERIOD 60
+
+typedef struct prv_smartlight_t {
+    kii_json_boolean_t power;
+    int brightness;
+    int color[3];
+    int color_temperature;
+} prv_smartlight_t;
+
+static prv_smartlight_t m_smartlight;
+
+static kii_json_parse_result_t prv_json_read_object(
+        const char* json,
+        size_t json_len,
+        kii_json_field_t* fields,
+        char error[EMESSAGE_SIZE + 1])
+{
+    kii_json_t kii_json;
+    kii_json_resource_t* resource_pointer = NULL;
+#ifndef KII_JSON_FIXED_TOKEN_NUM
+    kii_json_resource_t resource;
+    kii_json_token_t tokens[32];
+    resource_pointer = &resource;
+    resource.tokens = tokens;
+    resource.tokens_num = sizeof(tokens) / sizeof(tokens[0]);
+#endif
+
+    memset(&kii_json, 0, sizeof(kii_json));
+    kii_json.resource = resource_pointer;
+    kii_json.error_string_buff = error;
+    kii_json.error_string_length = EMESSAGE_SIZE + 1;
+
+    return kii_json_read_object(&kii_json, json, json_len, fields);
+}
+
+static kii_bool_t action_handler(
+        const char* schema,
+        int schema_version,
+        const char* action_name,
+        const char* action_params,
+        char error[EMESSAGE_SIZE + 1])
+{
+    printf("schema=%s, schema_version=%d, action name=%s, action params=%s\n",
+            schema, schema_version, action_name, action_params);
+
+    if (strcmp(schema, "SmartLightDemo") != 0 && schema_version != 1) {
+        printf("invalid schema: %s %d\n", schema, schema_version);
+        return KII_FALSE;
+    }
+
+    if (strcmp(action_name, "turnPower") == 0) {
+        kii_json_field_t fields[2];
+
+        memset(fields, 0x00, sizeof(fields));
+        fields[0].path = "/power";
+        fields[0].type = KII_JSON_FIELD_TYPE_BOOLEAN;
+        fields[1].path = NULL;
+        if(prv_json_read_object(action_params, strlen(action_params),
+                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
+            printf("invalid turnPower json\n");
+            return KII_FALSE;
+        }
+        m_smartlight.power = fields[0].field_copy.boolean_value;
+        return KII_TRUE;
+    } else if (strcmp(action_name, "setBrightness") == 0) {
+        kii_json_field_t fields[2];
+
+        memset(fields, 0x00, sizeof(fields));
+        fields[0].path = "/brightness";
+        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
+        fields[1].path = NULL;
+        if(prv_json_read_object(action_params, strlen(action_params),
+                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
+            printf("invalid brightness json\n");
+            return KII_FALSE;
+        }
+        m_smartlight.brightness = fields[0].field_copy.int_value;
+        return KII_TRUE;
+    } else if (strcmp(action_name, "setColor") == 0) {
+        kii_json_field_t fields[4];
+
+        memset(fields, 0x00, sizeof(fields));
+        fields[0].path = "/color/[0]";
+        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
+        fields[1].path = "/color/[1]";
+        fields[1].type = KII_JSON_FIELD_TYPE_INTEGER;
+        fields[2].path = "/color/[2]";
+        fields[2].type = KII_JSON_FIELD_TYPE_INTEGER;
+        fields[3].path = NULL;
+        if(prv_json_read_object(action_params, strlen(action_params),
+                         fields, error) !=  KII_JSON_PARSE_SUCCESS) {
+            printf("invalid color json\n");
+            return KII_FALSE;
+        }
+        m_smartlight.color[0] = fields[0].field_copy.int_value;
+        m_smartlight.color[1] = fields[1].field_copy.int_value;
+        m_smartlight.color[2] = fields[2].field_copy.int_value;
+        return KII_TRUE;
+    } else if (strcmp(action_name, "setColorTemperature") == 0) {
+        kii_json_field_t fields[2];
+
+        memset(fields, 0x00, sizeof(fields));
+        fields[0].path = "/colorTemperature";
+        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
+        fields[1].path = NULL;
+        if(prv_json_read_object(action_params, strlen(action_params),
+                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
+            printf("invalid colorTemperature json\n");
+            return KII_FALSE;
+        }
+        m_smartlight.color_temperature = fields[0].field_copy.int_value;
+        return KII_TRUE;
+    } else {
+        printf("invalid action: %s\n", action_name);
+        return KII_FALSE;
+    }
+}
+
+static kii_bool_t state_handler(
+        kii_t* kii,
+        KII_IOT_WRITER writer)
+{
+    char buf[256];
+    if ((*writer)(kii, "{\"power\":") == KII_FALSE) {
+        return KII_FALSE;
+    }
+    if ((*writer)(kii, m_smartlight.power == KII_JSON_TRUE
+                    ? "true," : "false,") == KII_FALSE) {
+        return KII_FALSE;
+    }
+    if ((*writer)(kii, "\"brightness\":") == KII_FALSE) {
+        return KII_FALSE;
+    }
+
+    sprintf(buf, "%d,", m_smartlight.brightness);
+    if ((*writer)(kii, buf) == KII_FALSE) {
+        return KII_FALSE;
+    }
+
+    if ((*writer)(kii, "\"color\":") == KII_FALSE) {
+        return KII_FALSE;
+    }
+    sprintf(buf, "[%d,%d,%d],", m_smartlight.color[0],
+            m_smartlight.color[1], m_smartlight.color[2]);
+    if ((*writer)(kii, buf) == KII_FALSE) {
+        return KII_FALSE;
+    }
+
+    if ((*writer)(kii, "\"colorTemperature\":") == KII_FALSE) {
+        return KII_FALSE;
+    }
+    sprintf(buf, "%d}", m_smartlight.color_temperature);
+    if ((*writer)(kii, buf) == KII_FALSE) {
+        return KII_FALSE;
+    }
+    return KII_TRUE;
+}
+
+int json_resource_cb(
+        kii_json_resource_t* resource,
+        size_t required_size)
+{
+    resource->tokens = (kii_json_token_t *)malloc(
+        sizeof(kii_json_token_t) * required_size);
+    resource->tokens_num = required_size;
+
+    return 1;
+}
+
+#define CMD_INDEX 1
+
+int kii_iot_main(int argc, char** argv)
+{
+    kii_iot_command_handler_resource_t command_handler_resource;
+    kii_iot_state_updater_resource_t state_updater_resource;
+    kii_iot_t* kii_iot;
+
+    kii_iot = malloc(sizeof(kii_iot_t));
+    memset(kii_iot, 0x00, sizeof(kii_iot_t));
+
+    command_handler_resource.buffer = malloc(sizeof(char) * EX_COMMAND_HANDLER_BUFF_SIZE);
+    command_handler_resource.buffer_size = EX_COMMAND_HANDLER_BUFF_SIZE;
+    command_handler_resource.mqtt_buffer = malloc(sizeof(char) * EX_MQTT_BUFF_SIZE);
+    command_handler_resource.mqtt_buffer_size = EX_MQTT_BUFF_SIZE;
+    command_handler_resource.action_handler = action_handler;
+
+    state_updater_resource.buffer = malloc(sizeof(char) * EX_STATE_UPDATER_BUFF_SIZE);
+    state_updater_resource.buffer_size = EX_STATE_UPDATER_BUFF_SIZE;
+    state_updater_resource.period = EX_STATE_UPDATE_PERIOD;
+    state_updater_resource.state_handler = state_handler;
+
+    if (ATH_STRCMP(argv[CMD_INDEX], "vendor-thing-id") == 0)
+    {
+        init_kii_iot(kii_iot, EX_APP_ID, EX_APP_KEY, EX_APP_SITE,
+                &command_handler_resource, &state_updater_resource,
+                json_resource_cb);
+        onboard_with_vendor_thing_id(kii_iot, EX_AUTH_VENDOR_ID,
+                EX_AUTH_VENDOR_PASS, NULL, NULL);
+    }
+    else if(ATH_STRCMP(argv[CMD_INDEX], "thing-id") == 0)
+    {
+        init_kii_iot(kii_iot, EX_APP_ID, EX_APP_KEY, EX_APP_SITE,
+                &command_handler_resource, &state_updater_resource,
+                json_resource_cb);
+        onboard_with_thing_id(kii_iot, EX_AUTH_THING_ID,
+                EX_AUTH_VENDOR_PASS);
+    }
+    else if(ATH_STRCMP(argv[CMD_INDEX], "onboarded") == 0)
+    {
+        init_kii_iot_with_onboarded_thing(kii_iot, EX_APP_ID, EX_APP_KEY,
+                EX_APP_SITE, EX_AUTH_THING_ID, EX_ACCESS_TOKEN,
+                &command_handler_resource, &state_updater_resource,
+                json_resource_cb);
+    }
+    else
+    {
+        printf("to configure parameters, edit example.h\n\n");
+        printf("commands: \n");
+        printf("  vendor-thing-id\n onboard to iot cloud with vendor thing ID.\n");
+        printf("  thing-id\n onboard to iot cloud with thing ID.\n");
+        printf("  onboarded\n join to onboarded iot cloud with thing ID and access token.\n");
+        printf("  help\n show this help.\n");
+    }
+
+    return 0;
+}

--- a/gt202/kii_iot_demo.h
+++ b/gt202/kii_iot_demo.h
@@ -1,0 +1,14 @@
+#ifndef __KII_IOT_DEMO
+#define __KII_IOT_DEMO
+
+#ifdef __cplusplus
+extern 'C' {
+#endif
+
+int kii_iot_main(int argc, char** argv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif//__KII_IOT_DEMO

--- a/gt202/kii_iot_environment_gt202.c
+++ b/gt202/kii_iot_environment_gt202.c
@@ -1,0 +1,119 @@
+#include "kii_iot_environment_impl.h"
+
+#include <gt202_kii_adapter.h>
+#include <kii_mqtt_socket.h>
+#include <kii_task_impl.h>
+
+kii_socket_code_t socket_connect_cb_impl(
+        kii_socket_context_t* socket_context,
+        const char* host,
+        unsigned int port)
+{
+    if (socket_context->app_context == NULL)
+    {
+        socket_context->app_context = (context_t*)malloc(sizeof(context_t));
+    }
+    return socket_connect_cb(socket_context, host, port);
+}
+
+kii_socket_code_t socket_send_cb_impl(
+        kii_socket_context_t* socket_context,
+        const char* buffer,
+        size_t length)
+{
+    return socket_send_cb(socket_context, buffer, length);
+}
+
+kii_socket_code_t socket_recv_cb_impl(
+        kii_socket_context_t* socket_context,
+        char* buffer,
+        size_t length_to_read,
+        size_t* out_actual_length)
+{
+    return socket_recv_cb(socket_context, buffer, length_to_read,
+            out_actual_length);
+}
+
+kii_socket_code_t socket_close_cb_impl(kii_socket_context_t* socket_context)
+{
+    kii_socket_code_t ret;
+
+    ret = socket_close_cb(socket_context);
+
+    if (socket_context->app_context != NULL)
+    {
+        free(socket_context->app_context);
+        socket_context->app_context = NULL;
+    }
+
+    return ret;
+}
+
+kii_socket_code_t mqtt_connect_cb_impl(
+        kii_socket_context_t* socket_context,
+        const char* host,
+        unsigned int port)
+{
+    if (socket_context->app_context == NULL)
+    {
+        socket_context->app_context = (context_t*)malloc(sizeof(context_t));
+    }
+    return mqtt_socket_connect(socket_context, host, port);
+}
+
+kii_socket_code_t mqtt_send_cb_impl(
+        kii_socket_context_t* socket_context,
+        const char* buffer,
+        size_t length)
+{
+    return mqtt_socket_send(socket_context, buffer, length);
+}
+
+kii_socket_code_t mqtt_recv_cb_impl(
+        kii_socket_context_t* socket_context,
+        char* buffer,
+        size_t length_to_read,
+        size_t* out_actual_length)
+{
+    return mqtt_socket_recv(socket_context, buffer, length_to_read,
+            out_actual_length);
+}
+
+kii_socket_code_t mqtt_close_cb_impl(kii_socket_context_t* socket_context)
+{
+    kii_socket_code_t ret;
+
+    ret = mqtt_socket_close(socket_context);
+
+    if (socket_context->app_context != NULL)
+    {
+        free(socket_context->app_context);
+        socket_context->app_context = NULL;
+    }
+
+    return ret;
+}
+
+kii_task_code_t task_create_cb_impl(
+        const char* name,
+        KII_TASK_ENTRY entry,
+        void* param,
+        unsigned char* stk_start,
+        unsigned int stk_size,
+        unsigned int priority)
+{
+    return task_create_cb(name, entry, param, stk_start, stk_size, priority);
+}
+
+void delay_ms_cb_impl(unsigned int msec)
+{
+    delay_ms_cb(msec);
+}
+
+void logger_cb_impl(const char* format, ...)
+{
+    va_list list;
+    va_start(list, format);
+    vprintf(format, list);
+    va_end(list);
+}

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -52,6 +52,7 @@ static kii_json_parse_result_t prv_kii_thing_if_json_read_object(
         sizeof(error_message) / sizeof(error_message[0]);
 
     kii_json.resource = &(kii->kii_json_resource);
+    kii_json.resource_cb = kii->kii_json_resource_cb;
     retval = kii_json_read_object(&kii_json, json_string, json_string_size,
                 fields);
 


### PR DESCRIPTION
GT202でIoTCloud-ThingSDKを利用したサンプルコードです。vendor-thing-id、thing-idの2つのコマンドでlinux-sampleのREADMEに書かれているレスポンスと同じものを受け取ることを確認しました。

ただ、onboardedに関してはどのような動作になるかわかりませんでした。
(cygwinだと"failed to get host."が繰り返しでる。)
GT202上でonboardedを実行するとすこし間を置いて"failed to init ssl context."が繰り返しでるようになります。
出すメッセージが違うだけでcygwinと同じ症状では無いかと思われます。

とりあえすonboardedに関しては後々ということで、できている分をPRします。
