### PR TITLE
m_smartlight is accessed exclusively.

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -474,7 +474,7 @@ static void received_callback(kii_t* kii, char* buffer, size_t buffer_size) {
                         return;
                     }
                     if (kii_api_call_append_body(kii,
-                                    "\"}}", sizeof("\"}}") - 1) != 0) {
+                                    "\"}", sizeof("\"}") - 1) != 0) {
                         M_KII_LOG(kii->kii_core.logger_cb(
                                 "request size overflowed.\n"));
                         return;

--- a/linux-sample/example.c
+++ b/linux-sample/example.c
@@ -92,12 +92,14 @@ static kii_bool_t action_handler(
 
     if (strcmp(schema, "SmartLightDemo") != 0 && schema_version != 1) {
         printf("invalid schema: %s %d\n", schema, schema_version);
+        sprintf(error, "invalid schema: %s %d", schema, schema_version);
         return KII_FALSE;
     }
 
     memset(&smartlight, 0x00, sizeof(smartlight));
     if (prv_get_smartlight_info(&smartlight) == KII_FALSE) {
         printf("fail to lock.\n");
+        strcpy(error, "fail to lock.");
         return KII_FALSE;
     }
     if (strcmp(action_name, "turnPower") == 0) {

--- a/linux-sample/example.c
+++ b/linux-sample/example.c
@@ -415,10 +415,8 @@ int main(int argc, char** argv)
     while(1){}; /* run forever. */
 
     /*
-     * This sample application does not stop so we can not destroy
-     * mutex.  If your applicatin can stop manually, you need to
-     * destroy mutex like this:
-     *
+     * This sample application keeps mutex from the start to end
+     * of the applicatoin process. So we don't implement destry.
      * pthread_mutex_destroy(&m_mutex);
     */
 }


### PR DESCRIPTION
External variable `m_smartlight` is accessed exclusively.

I found another bug. JSON string which is sent when command failed was invalid. So I fixed it together.
