### PR TITLE
add override directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -std=gnu89 -Wall -pedantic -pthread -fPIC -shared
+override CFLAGS += -std=gnu89 -Wall -pedantic -pthread -fPIC -shared
 
 ifdef DEBUG
 	CFLAGS += -g -DDEBUG

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-override CFLAGS += -std=gnu89 -Wall -pedantic -pthread -fPIC -shared
-
 ifdef DEBUG
-	CFLAGS += -g -DDEBUG
+	override CFLAGS += -g -DDEBUG
 endif
+override CFLAGS += -std=gnu89 -Wall -pedantic -pthread -fPIC -shared
 
 LIBS = -lssl -lcrypto -lpthread
 SOURCES = kii_thing_if.c


### PR DESCRIPTION
override directive can modify CFLAGS through command line argument.

if you pass CFLAGS=-DKII_JSON_FIXED_TOKEN_NUM=256 to make command.
`make CFLAGS=-DKII_JSON_FIXED_TOKEN_NUM=256`
make command will append `-DKII_JSON_FIXED_TOKEN_NUM=256` to CFLAGS.
ex. `CFLAGS=-DKII_JSON_FIXED_TOKEN_NUM=256 -std=gnu89 -Wall -pedantic -pthread -fPIC -shared`

ref. https://www.gnu.org/software/make/manual/html_node/Override-Directive.html#Override-Directive
