### PR TITLE
Enable to handle push notification other than command

### DIFF
--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -105,33 +105,40 @@ typedef kii_bool_t
         (kii_t* kii,
          KII_THING_IF_WRITER writer);
 
-/**
- * callback function to enable to handle all notifications.
+/** callback function enables to handle all push notifications.
  *
- * Servers sends notification when
- * - Objects in subscribed buckets are modified.
- * - Messages are sent to the subscribed topics
- * - Commands are sent from server.
+ * This handler is optional and only used for advanced use-cases.
+ * Push notification will be sent to the thing in following cases.
+ * - Subscribed buckets events
+ * - Messages sent to the subscribed topics
+ * - Commands sent to this thing.
  *
- * This handler can handle such notifications.
+ * Normally you don't need to implement this handler.
+ * Without this handler, SDK only deals with push notification includes
+ * Command. In this case, SDK parses the push notification and if its a 
+ * valid Command to the thing, #KII_THING_IF_ACTION_HANDLER will be called.
  *
- * Usually command notifications should be handled with
- * #KII_THING_IF_ACTION_HANDLER, so this handler should be handle
- * bucket notifications and topic notifications. Of course you can
- * handle command notifications in this handler but it is not good
- * manner.
+ * This handler will be implemented and passed to #kii_thing_if_t
+ * in case you need to handle bucket events notification, messages arrived to
+ * subscribed topic or need to implement custom procedure when received a
+ * Commands sent to this thing.
+ *
+ * You can choose by retruning KII_TRUE or KII_FALSE whether to let SDK to
+ * continue handling with default logic which deals with Command push
+ * notification.
  *
  * @param [in] kii_t kii_t object if you want to send request to kii
  * cloud you can use this kii_t object.
  * @param [in] message notification message
  * @param [in] message_length length of message.
  * @return
- * - KII_TRUE, then ThingSDK skips to handle command
- * notification. Usually this handler should return KII_TRUE if
- * receiving message is bucket notification or topic notification.
- * - KII_FALSE, then ThingSDK proceeds to handle command
- * notification. Usually, this handler should return KII_FALSE if
- * receiving message is command notification.
+ * - KII_TRUE Let SDK to skip executing default logic handles Command.
+ *   In this case #KII_THING_IF_ACTION_HANDLER won't be called even if the
+ *   push notification includes valid Command.
+ * - KII_FALSE Let SDK to execute default logic handles Command. If the push
+ *   notification includes valid Command, #KII_THING_IF_ACTION_HANDLER will be
+ *   called.
+ *   (If the push notification is not Command, would be ignored safely.) 
  */
 typedef kii_bool_t
     (*KII_THING_IF_CUSTOM_PUSH_HANDLER)
@@ -176,10 +183,11 @@ typedef struct kii_thing_if_command_handler_resource_t {
      */
     KII_THING_IF_STATE_HANDLER state_handler;
 
-    /**
-     * callback function to handle recived all push
-     * notifications. This field can be NULL if your application does
-     * not have custom push procedure.
+    /** callback function to handle recived all push notifications.
+     * Normally you can left this field as NULL.
+     * Only required when you have to deal with push notification with your
+     * custom logic.
+     * @see KII_THING_IF_CUSTOM_PUSH_HANDLER
      */
     KII_THING_IF_CUSTOM_PUSH_HANDLER custom_push_handler;
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -106,10 +106,22 @@ typedef kii_bool_t
          KII_THING_IF_WRITER writer);
 
 /**
+ * callback function for handling message from pushing to application.
+ * @param [in] kii_t kii_t object if you want to send request to kii
+ * cloud you can use this kii_t object.
+ * @param [in] message message from pushing to application.
+ */
+typedef kii_bool_t
+    (*KII_THING_IF_PUSH_TO_APP_HANDLER)
+        (const kii_t *kii,
+         const char* message);
+
+/**
  * Resource for command handler.
  *
- * Invocation of #action_handler and #state_handler callback inside this struct
- * is serialized since they are called from the single task/thread.
+ * Invocation of #action_handler, #state_handler and
+ * #push_to_app_handler callback inside this struct is serialized
+ * since they are called from the single task/thread.
  *
  * However, kii_thing_if_state_updater_resource_t#state_handler and callbacks
  * inside this struct is invoked from different task/ thread.
@@ -140,6 +152,12 @@ typedef struct kii_thing_if_command_handler_resource_t {
      * processed.
      */
     KII_THING_IF_STATE_HANDLER state_handler;
+
+    /**
+     * callback function to handle recived push to application message.
+     */
+    KII_THING_IF_PUSH_TO_APP_HANDLER push_to_app_handler;
+
 } kii_thing_if_command_handler_resource_t;
 
 /**

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -106,13 +106,13 @@ typedef kii_bool_t
          KII_THING_IF_WRITER writer);
 
 /**
- * callback function for handling message from pushing to application.
+ * callback function for handling notification.
  * @param [in] kii_t kii_t object if you want to send request to kii
  * cloud you can use this kii_t object.
  * @param [in] message message from pushing to application.
  */
 typedef kii_bool_t
-    (*KII_THING_IF_PUSH_TO_APP_HANDLER)
+    (*KII_THING_IF_NOTIFICATION_HANDLER)
         (const kii_t *kii,
          const char* message);
 
@@ -120,7 +120,7 @@ typedef kii_bool_t
  * Resource for command handler.
  *
  * Invocation of #action_handler, #state_handler and
- * #push_to_app_handler callback inside this struct is serialized
+ * #notification_handler callback inside this struct is serialized
  * since they are called from the single task/thread.
  *
  * However, kii_thing_if_state_updater_resource_t#state_handler and callbacks
@@ -154,9 +154,9 @@ typedef struct kii_thing_if_command_handler_resource_t {
     KII_THING_IF_STATE_HANDLER state_handler;
 
     /**
-     * callback function to handle recived push to application message.
+     * callback function to handle recived notification.
      */
-    KII_THING_IF_PUSH_TO_APP_HANDLER push_to_app_handler;
+    KII_THING_IF_NOTIFICATION_HANDLER notification_handler;
 
 } kii_thing_if_command_handler_resource_t;
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -107,9 +107,16 @@ typedef kii_bool_t
 
 /**
  * callback function for handling notification.
+ *
+ * Servers sends notification when
+ * - Objects in subscribed buckets are modified.
+ * - Messages are send to the subscribed topics
+ *
+ * This handler handles such notifications.
+ *
  * @param [in] kii_t kii_t object if you want to send request to kii
  * cloud you can use this kii_t object.
- * @param [in] message message from pushing to application.
+ * @param [in] message notification message
  * @param [in] message_length length of message.
  */
 typedef void
@@ -157,7 +164,7 @@ typedef struct kii_thing_if_command_handler_resource_t {
 
     /**
      * callback function to handle recived notification. This field
-     * can be NULL. If NULL then notifications excepting command
+     * can be NULL. If NULL then notifications except command
      * action does not be notified to application.
      */
     KII_THING_IF_NOTIFICATION_HANDLER notification_handler;

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -112,7 +112,7 @@ typedef kii_bool_t
  * @param [in] message message from pushing to application.
  * @param [in] message_length length of message.
  */
-typedef kii_bool_t
+typedef void
     (*KII_THING_IF_NOTIFICATION_HANDLER)
         (kii_t *kii,
          const char* message,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -156,7 +156,9 @@ typedef struct kii_thing_if_command_handler_resource_t {
     KII_THING_IF_STATE_HANDLER state_handler;
 
     /**
-     * callback function to handle recived notification.
+     * callback function to handle recived notification. This field
+     * can be NULL. If NULL then notifications excepting command
+     * action does not be notified to application.
      */
     KII_THING_IF_NOTIFICATION_HANDLER notification_handler;
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -114,7 +114,7 @@ typedef kii_bool_t
  */
 typedef kii_bool_t
     (*KII_THING_IF_NOTIFICATION_HANDLER)
-        (const kii_t *kii,
+        (kii_t *kii,
          const char* message,
          size_t message_length);
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -110,11 +110,13 @@ typedef kii_bool_t
  * @param [in] kii_t kii_t object if you want to send request to kii
  * cloud you can use this kii_t object.
  * @param [in] message message from pushing to application.
+ * @param [in] message_length length of message.
  */
 typedef kii_bool_t
     (*KII_THING_IF_NOTIFICATION_HANDLER)
         (const kii_t *kii,
-         const char* message);
+         const char* message,
+         size_t message_length);
 
 /**
  * Resource for command handler.

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -106,21 +106,35 @@ typedef kii_bool_t
          KII_THING_IF_WRITER writer);
 
 /**
- * callback function for handling notification.
+ * callback function to enable to handle all notifications.
  *
  * Servers sends notification when
  * - Objects in subscribed buckets are modified.
- * - Messages are send to the subscribed topics
+ * - Messages are sent to the subscribed topics
+ * - Commands are sent from server.
  *
- * This handler handles such notifications.
+ * This handler can handle such notifications.
+ *
+ * Usually command notifications should be handled with
+ * #KII_THING_IF_ACTION_HANDLER, so this handler should be handle
+ * bucket notifications and topic notifications. Of course you can
+ * handle command notifications in this handler but it is not good
+ * manner.
  *
  * @param [in] kii_t kii_t object if you want to send request to kii
  * cloud you can use this kii_t object.
  * @param [in] message notification message
  * @param [in] message_length length of message.
+ * @return
+ * - KII_TRUE, then ThingSDK skips to handle command
+ * notification. Usually this handler should return KII_TRUE if
+ * receiving message is bucket notification or topic notification.
+ * - KII_FALSE, then ThingSDK proceeds to handle command
+ * notification. Usually, this handler should return KII_FALSE if
+ * receiving message is command notification.
  */
-typedef void
-    (*KII_THING_IF_NOTIFICATION_HANDLER)
+typedef kii_bool_t
+    (*KII_THING_IF_CUSTOM_PUSH_HANDLER)
         (kii_t *kii,
          const char* message,
          size_t message_length);
@@ -129,7 +143,7 @@ typedef void
  * Resource for command handler.
  *
  * Invocation of #action_handler, #state_handler and
- * #notification_handler callback inside this struct is serialized
+ * #custom_push_handler callback inside this struct is serialized
  * since they are called from the single task/thread.
  *
  * However, kii_thing_if_state_updater_resource_t#state_handler and callbacks
@@ -163,11 +177,11 @@ typedef struct kii_thing_if_command_handler_resource_t {
     KII_THING_IF_STATE_HANDLER state_handler;
 
     /**
-     * callback function to handle recived notification. This field
-     * can be NULL. If NULL then notifications except command
-     * action does not be notified to application.
+     * callback function to handle recived all push
+     * notifications. This field can be NULL if your application does
+     * not have custom push procedure.
      */
-    KII_THING_IF_NOTIFICATION_HANDLER notification_handler;
+    KII_THING_IF_CUSTOM_PUSH_HANDLER custom_push_handler;
 
 } kii_thing_if_command_handler_resource_t;
 


### PR DESCRIPTION
command以外のpush notificationを処理するハンドラのAPIを設計しました。

``` c
typedef kii_bool_t
    (*KII_THING_IF_PUSH_TO_APP_HANDLER)
        (const kii_t *kii,
         const char* message);
```

上記のようなハンドラにしました。第一引数のkiiオブジェクトはcommand handler用に作成されたオブジェクトを渡す想定です。岸本さんに伺ったところ、notificationを受けた後には、KiiCouldのREST APIを叩きたい場合もあるということなので、追加しました。

現在の想定では、command handlerの受信をしているのと同一のタスクまたはスレッドで、このハンドラを呼び出す想定です。ハンドラの処理が重くなると、MQTTの受信が滞る可能性があります。この場合は、ハンドラの処理自体を別タスクまたはスレッドに任せるという方法をとる必要があります。ただ、別タスクまたはスレッドに任せると、タスク間協調が必要になり、ロックが必要になります。また、別タスクに渡す際には別途メッセージを乗せるためのバッファが必要になるため、メモリ容量的に現実的ではないかもしれません。

この点については、別途相談させていただきたいと思っています。

Related issue No. 896
Release version 1.2.0
