### PR TITLE
continue update status when error.

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -739,19 +739,20 @@ static void* prv_update_status(void *sdata)
                         KII_TRUE) != 0) {
             M_KII_LOG(kii->kii_core.logger_cb(
                     "fail to start api call.\n"));
-            return NULL;
+            continue;
         }
         if (((kii_thing_if_t*)kii->app_context)->state_handler_for_period(kii,
                         prv_writer) == KII_FALSE) {
             M_KII_LOG(kii->kii_core.logger_cb(
                     "fail to start api call.\n"));
-            return NULL;
+            continue;
         }
         if (kii_api_call_run(kii) != 0) {
             M_KII_LOG(kii->kii_core.logger_cb("fail to run api.\n"));
-            return NULL;
+            continue;
         }
     }
+    return NULL;
 }
 
 static kii_bool_t prv_set_author(


### PR DESCRIPTION
通信エラーの際に、Onboard時に実行したステータスをサーバへ送信するタスク(prv_update_status)が終了してしまうため、
更新されたステータスが届かなくなるのでネットワーク再開後に通信できていないように見えていた模様です。

通信エラーなどがあってもステータス送信を継続ようにタスク内を修正しました。

Issue: #58 
