### PR TITLE
Regular expression is fixed.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,6 @@ test:
 
 deployment:
   production:
-    tag: /v[0-9]+.*/
+    tag: /^v[0-9]+(\.[0-9]+){0,2}((-.*)?)?$/
     commands:
       - bash circleci_scripts/release_doc.sh


### PR DESCRIPTION
According to [this comment](https://github.com/KiiPlatform/thing-if-JSSDK/pull/163#discussion_r90207175), Regular expression to match tag name is fixed.

I have tested to upload API document with staging server. The build is [this](https://circleci.com/gh/KiiPlatform/thing-if-ThingSDK/229)