### PR TITLE
Fix action handler API.

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -437,6 +437,10 @@ static void handle_command(kii_t* kii, char* buffer, size_t buffer_size)
                 value_swap = value[value_len];
                 key[key_len] = '\0';
                 value[value_len] = '\0';
+
+                /* TODO: implement me. */
+                M_KII_THING_IF_ASSERT(0);
+                /*
                 if ((*handler)(schema, schema_version, key, value, error)
                         != KII_FALSE) {
                     if (kii_api_call_append_body(kii,
@@ -491,6 +495,7 @@ static void handle_command(kii_t* kii, char* buffer, size_t buffer_size)
                 }
                 key[key_len] = key_swap;
                 value[value_len] = value_swap;
+                */
             }
             case KII_JSON_PARSE_PARTIAL_SUCCESS:
                 /* This must be end of array. */

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -12,8 +12,7 @@ extern "C" {
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
 
 /** callback function for handling action.
- * @param [in] schema name of schema.
- * @maram [in] schema_version version of schema.
+ * @param [in] alias name of schema.
  * @param [in] action_name name of the action.
  * @param [in] action_params json object represents parameter of this action.
  * @param [out] error error message if operation is failed.(optional)
@@ -21,8 +20,7 @@ extern "C" {
  */
 typedef kii_bool_t
     (*KII_THING_IF_ACTION_HANDLER)
-        (const char* schema,
-         int schema_version,
+        (const char* alias,
          const char* action_name,
          const char* action_params,
          char error[EMESSAGE_SIZE + 1]);

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -12,7 +12,7 @@ extern "C" {
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
 
 /** callback function for handling action.
- * @param [in] alias name of schema.
+ * @param [in] alias name of alias.
  * @param [in] action_name name of the action.
  * @param [in] action_params json object represents parameter of this action.
  * @param [out] error error message if operation is failed.(optional)


### PR DESCRIPTION
### API Changes

* Remove `schema` and `schema_version`.
* Add `alias`.

### Behavior of action handler

Example of receiving payload of command is following:

```js
{
  "commandID" : "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
  "actions":[
    {
      "AirConditionerAlias": [
        {
          "turnPower" : true
        },
        {
          "setPresetTemperature" : 25
        }
      ]
    },
    {
      "HumidityAlias": [
        {
          "setPresetHumidity" : 45
        }
      ]
    }
  ],
  "issuer":"user:XXXXXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX"
}
```

To notify such command in our design: 

1. one action handler call notifies one action
1. an action handler also notify alias associated to the action in one action handler call.

In the above example, An action handler notifies followings:

1. `alias` = AirConditionerAlias, `action_name` = turnPower, `action_param` = true
2. `alias` = AirConditionerAlias, `action_name` = setPresetTemperature, `action_param` = 25
3. `alias` = HumidityAlias, `action_name` = setPresetHumidity, `action_param` = 45

### Notice

There is no specification about payload of mqtt receiving command. I designed this API with mqtt response. In other words, I designed this with real server behavior.

The specification might be creating now so we may change this API according to created specification.

Related PR: #80 
