### PR TITLE
Update firmware version and thing type in onboarding functions

### DIFF
--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -274,12 +274,12 @@ kii_bool_t init_kii_thing_if(
  * vendor. Must not be NULL and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If the thing is already
- * registered, this value would be ignored by Kii Cloud. If this value
- * is NULL or empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If the
- * thing is already registered, this value would be ignored by Kii
- * Cloud. If this value is NULL or empty string this value is ignored.
+ * @param [in] thing_type Type of the thing. If users specify
+ * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
+ * empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If
+ * users specify firmware_version, this SDK updates firmware version
+ * in Kii Cloud. If NULL or empty string, this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If
@@ -310,12 +310,12 @@ kii_bool_t onboard_with_vendor_thing_id(
  * and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If the thing is already
- * registered, this value would be ignored by Kii Cloud. If this value
- * is NULL or empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If the
- * thing is already registered, this value would be ignored by Kii
- * Cloud. If this value is NULL or empty string this value is ignored.
+ * @param [in] thing_type Type of the thing. If users specify
+ * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
+ * empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If
+ * users specify firmware_version, this SDK updates firmware version
+ * in Kii Cloud. If NULL or empty string, this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If


### PR DESCRIPTION
According to this comment https://github.com/KiiPlatform/thing-if-ThingSDK/pull/80#pullrequestreview-33416557, we need to fix API to update firmware version and thing type.

I suggest a way to update firmware version and thing type in onboarding functions so I only change API document for onboarding functions in this PR.

### Reason to avoid adding new functions

If we introduce new functions to update firmware version and thing type, we must think about thread safe and stack size. We need a `kii_t` instance to send HTTP requests to Kii Cloud in thing-if ThingSDK. `kii_thing_if_t` instance has `kii_t` instances but we can not use it because of securing thread safe. `kii_t` instances in `kii_thing_if_t` instance are asynchronously used to receive command or to send states. If we use the `kii_t` instances to send updating request, the request and response message must be broken because of multi thread access.

On the other hand, if we force developers to create new a `kii_t` instance for updating, that requires a lot of stack or heap memory. `kii_t` instance requires request and response http buffer. This might be big memory for thing. Things have only limited memory. We should avoid it.

### Why can we update these in onboarding?

I told about this to kumano san, He said **"What about using one of `kii_t` instances in `kii_thing_if_t` instance and limiting timing? Developes might want to update the information right after onboarding"** I completely agreed with his opinion. Updating the information must be concerned with updating of thing firmware.

Related PR: #80 