### PR TITLE
Design update firmware version and thing type

### DIFF
--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -22,7 +22,9 @@ typedef enum kii_thing_if_error_t {
     /** A buffer size provided from applications is shorter than a
      * function can copy the information got from Kii Cloud.
      */
-    KII_THING_IF_ERROR_LENGTH_EXCEEDED
+    KII_THING_IF_ERROR_LENGTH_EXCEEDED,
+    /** thing-if ThingSDK is alreday started. */
+    KII_THING_IF_ERROR_ALREADY_STARTED
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -430,6 +432,7 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -456,6 +459,7 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -478,6 +482,7 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -504,6 +509,7 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -9,6 +9,22 @@
 extern "C" {
 #endif
 
+/** Enumeration representing error of thing-if ThingSDK. */
+typedef enum kii_thing_if_error_t {
+    /** Functions succeed. There is no error. */
+    KII_THING_IF_ERROR_NO_ERROR = 0,
+    /** Information trying to get from a function is not found. */
+    KII_THING_IF_ERROR_TARGET_NOT_FOUND,
+    /** Thing is not found in Kii Cloud. */
+    KII_THING_IF_ERROR_THING_NOT_FOUND,
+    /** kii_thing_if_t instance is not onbarded. Please onboard first. */
+    KII_THING_IF_ERROR_NOT_ONBOARDED,
+    /** A buffer size provided from applications is shorter than a
+     * function can copy the information got from Kii Cloud.
+     */
+    KII_THING_IF_ERROR_LENGTH_EXCEEDED
+} kii_thing_if_error_t;
+
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
 
 /** callback function for handling action.
@@ -410,7 +426,7 @@ kii_bool_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
         const char* firmware_version);
 
-/** Get current firmware version of a thing.
+/** Get firmware version of a thing.
  *
  * This function must be called between ::start and one of
  * following functions:
@@ -418,23 +434,24 @@ kii_bool_t update_firmware_version(
  * - ::onboard_with_thing_id
  * - ::init_kii_thing_if_with_onboarded_thing
  *
- * Applications <b> must not free </b> the returned value.
- *
- * The returned value is valid until other API is called. After other
- * API is called, the returned value might be broken. If you want to
- * use the returned value over other API call, you need to copy the
- * returned value in your own.
- *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return current firmware version. Contents of the return value is
- * one of the followings:
- * - If succeed to get current firmware version, this function
- *   returnes null terminated string denoting firmware version.
- * - If thing does not have firmware version, this function returns
- *   empty string. This string also null terminated.
- * - Otherwise, returns NULL.
+ * @param [out] firmware_version a buffer to copy firmware version got
+ * from Kii Cloud. This SDK makes the buffer null terminated string.
+ * @param [in] firmware_version_len length of firmware_version which
+ * is second argument of this function.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_TARGET_NOT_FOUND | Thing has no firmware version. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  */
-const char* get_firmware_version(kii_thing_if_t* kii_thing_if);
+kii_thing_if_error_t get_firmware_version(
+        kii_thing_if_t* kii_thing_if,
+        char* firmware_version,
+        size_t firmware_version_len);
 
 /** Upate thing type of a thing.
  *
@@ -460,23 +477,24 @@ kii_bool_t update_thing_type(
  * - ::onboard_with_thing_id
  * - ::init_kii_thing_if_with_onboarded_thing
  *
- * Applications <b> must not free </b> the returned value.
- *
- * The returned value is valid until other API is called. After other
- * API is called, the returned value might be broken. If you want to
- * use the returned value over other API call, you need to copy the
- * returned value in your own.
- *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return current thing type. Contents of the return value is one of
- * the followings:
- * - If succeed to get current thing type, this function
- *   returnes null terminated string denoting thing type.
- * - If thing does not have thing type, this function returns
- *   empty string. This string also null terminated.
- * - Otherwise, returns NULL.
+ * @param [out] thing_type a buffer to copy thing type got
+ * from Kii Cloud. This SDK makes the buffer null terminated string.
+ * @param [in] thing_type_len length of thing_type which
+ * is second argument of this function.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_TARGET_NOT_FOUND | Thing has no thing type. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  */
-const char* get_thing_type(kii_thing_if_t* kii_thing_if);
+kii_thing_if_error_t get_thing_type(
+        kii_thing_if_t* kii_thing_if,
+        char* thing_type,
+        size_t thing_type_len);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -1,4 +1,3 @@
-/** @file */
 #ifndef _KII_THING_IF_
 #define _KII_THING_IF_
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -1,3 +1,4 @@
+/** @file */
 #ifndef _KII_THING_IF_
 #define _KII_THING_IF_
 
@@ -266,6 +267,21 @@ kii_bool_t init_kii_thing_if(
         kii_thing_if_state_updater_resource_t* state_updater_resource,
         KII_JSON_RESOURCE_CB resource_cb);
 
+/** Activate kii_thing_if_t instance.
+ *
+ * thing-if ThingSDK starts to receive command and update states with
+ * this function.
+ *
+ * This function must be called after one of following functions
+ * - ::onboard_with_vendor_thing_id,
+ * - ::onboard_with_thing_id
+ * - ::init_kii_thing_if_with_onboarded_thing
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ */
+kii_bool_t activate(kii_thing_if_tg* kii_thing_if);
+
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
  * used to call api.
@@ -378,6 +394,40 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_command_handler_resource_t* command_handler_resource,
         kii_thing_if_state_updater_resource_t* state_updater_resource,
         KII_JSON_RESOURCE_CB resource_cb);
+
+/** Upate firmware version of a thing.
+ *
+ * This function must be called between ::activate and one of
+ * following functions:
+ * - ::onboard_with_vendor_thing_id,
+ * - ::onboard_with_thing_id
+ * - ::init_kii_thing_if_with_onboarded_thing
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @param [in] firmware_version firmware version to update.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ */
+kii_bool_t update_firmware_version(
+        kii_thing_if_t* kii_thing_if,
+        const char* firmware_version);
+
+/** Get current firmware version of a thing.
+ *
+ * This function must be called between ::activate and one of
+ * following functions:
+ * - ::onboard_with_vendor_thing_id,
+ * - ::onboard_with_thing_id
+ * - ::init_kii_thing_if_with_onboarded_thing
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @param [out] current_firmware_version current firmware
+ * version. This is null terminated string. Application must not free
+ * this memory. If execution fails, NULL is assigned.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ */
+kii_bool_t get_current_firmware_version(
+        kii_thing_if_t* kii_thing_if,
+        char** current_firmware_version);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -418,9 +418,12 @@ kii_bool_t update_firmware_version(
  * - ::onboard_with_thing_id
  * - ::init_kii_thing_if_with_onboarded_thing
  *
- * Applications <b> must not free </b> the returned value. The
- * returned value is valid until other API is called. After other API
- * is called, the returned value might be broken.
+ * Applications <b> must not free </b> the returned value.
+ *
+ * The returned value is valid until other API is called. After other
+ * API is called, the returned value might be broken. If you want to
+ * use the returned value over other API call, you need to copy the
+ * returned value in your own.
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @return current firmware version. Contents of the return value is
@@ -432,6 +435,48 @@ kii_bool_t update_firmware_version(
  * - Otherwise, returns NULL.
  */
 const char* get_current_firmware_version(kii_thing_if_t* kii_thing_if);
+
+/** Upate thing type of a thing.
+ *
+ * This function must be called between ::activate and one of
+ * following functions:
+ * - ::onboard_with_vendor_thing_id,
+ * - ::onboard_with_thing_id
+ * - ::init_kii_thing_if_with_onboarded_thing
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @param [in] thing_type thing type to update.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ */
+kii_bool_t update_thing_type(
+        kii_thing_if_t* kii_thing_if,
+        const char* thing_type);
+
+/** Get current thing type of a thing.
+ *
+ * This function must be called between ::activate and one of
+ * following functions:
+ * - ::onboard_with_vendor_thing_id,
+ * - ::onboard_with_thing_id
+ * - ::init_kii_thing_if_with_onboarded_thing
+ *
+ * Applications <b> must not free </b> the returned value.
+ *
+ * The returned value is valid until other API is called. After other
+ * API is called, the returned value might be broken. If you want to
+ * use the returned value over other API call, you need to copy the
+ * returned value in your own.
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @return current thing type. Contents of the return value is one of
+ * the followings:
+ * - If succeed to get current thing type, this function
+ *   returnes null terminated string denoting thing type.
+ * - If thing does not have thing type, this function returns
+ *   empty string. This string also null terminated.
+ * - Otherwise, returns NULL.
+ */
+const char* get_current_thing_type(kii_thing_if_t* kii_thing_if);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -418,15 +418,19 @@ kii_bool_t update_firmware_version(
  * - ::onboard_with_thing_id
  * - ::init_kii_thing_if_with_onboarded_thing
  *
+ * Applications <b> must not free </b> the returned value. The
+ * returned value is valid until other API is called. After other API
+ * is called, the returned value might be broken.
+ *
  * @param [in] kii_thing_if_t This SDK instance.
- * @param [out] current_firmware_version current firmware
- * version. This is null terminated string. Application must not free
- * this memory. If execution fails, NULL is assigned.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return current firmware version. This is null terminated string.
+ * - If succeed to get current firmware version, this function
+ *   returnes null terminated string denoting firmware version.
+ * - If thing does not have firmware version, this function returns
+ *   empty string. This string also null terminated.
+ * - Otherwise, returns NULL.
  */
-kii_bool_t get_current_firmware_version(
-        kii_thing_if_t* kii_thing_if,
-        char** current_firmware_version);
+const char* get_current_firmware_version(kii_thing_if_t* kii_thing_if);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -279,7 +279,7 @@ kii_bool_t init_kii_thing_if(
  * @param [in] kii_thing_if_t This SDK instance.
  * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
-kii_bool_t activate(kii_thing_if_tg* kii_thing_if);
+kii_bool_t activate(kii_thing_if_t* kii_thing_if);
 
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -420,9 +420,14 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] firmware_version firmware version to update.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
-kii_bool_t update_firmware_version(
+kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
         const char* firmware_version);
 
@@ -463,9 +468,14 @@ kii_thing_if_error_t get_firmware_version(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] thing_type thing type to update.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
-kii_bool_t update_thing_type(
+kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
         const char* thing_type);
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -434,7 +434,7 @@ kii_bool_t update_firmware_version(
  *   empty string. This string also null terminated.
  * - Otherwise, returns NULL.
  */
-const char* get_current_firmware_version(kii_thing_if_t* kii_thing_if);
+const char* get_firmware_version(kii_thing_if_t* kii_thing_if);
 
 /** Upate thing type of a thing.
  *
@@ -476,7 +476,7 @@ kii_bool_t update_thing_type(
  *   empty string. This string also null terminated.
  * - Otherwise, returns NULL.
  */
-const char* get_current_thing_type(kii_thing_if_t* kii_thing_if);
+const char* get_thing_type(kii_thing_if_t* kii_thing_if);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -266,7 +266,7 @@ kii_bool_t init_kii_thing_if(
         kii_thing_if_state_updater_resource_t* state_updater_resource,
         KII_JSON_RESOURCE_CB resource_cb);
 
-/** Activate kii_thing_if_t instance.
+/** Start kii_thing_if_t instance.
  *
  * thing-if ThingSDK starts to receive command and update states with
  * this function.
@@ -279,7 +279,7 @@ kii_bool_t init_kii_thing_if(
  * @param [in] kii_thing_if_t This SDK instance.
  * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
-kii_bool_t activate(kii_thing_if_t* kii_thing_if);
+kii_bool_t start(kii_thing_if_t* kii_thing_if);
 
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
@@ -396,7 +396,7 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
 
 /** Upate firmware version of a thing.
  *
- * This function must be called between ::activate and one of
+ * This function must be called between ::start and one of
  * following functions:
  * - ::onboard_with_vendor_thing_id,
  * - ::onboard_with_thing_id
@@ -412,7 +412,7 @@ kii_bool_t update_firmware_version(
 
 /** Get current firmware version of a thing.
  *
- * This function must be called between ::activate and one of
+ * This function must be called between ::start and one of
  * following functions:
  * - ::onboard_with_vendor_thing_id,
  * - ::onboard_with_thing_id
@@ -438,7 +438,7 @@ const char* get_current_firmware_version(kii_thing_if_t* kii_thing_if);
 
 /** Upate thing type of a thing.
  *
- * This function must be called between ::activate and one of
+ * This function must be called between ::start and one of
  * following functions:
  * - ::onboard_with_vendor_thing_id,
  * - ::onboard_with_thing_id
@@ -454,7 +454,7 @@ kii_bool_t update_thing_type(
 
 /** Get current thing type of a thing.
  *
- * This function must be called between ::activate and one of
+ * This function must be called between ::start and one of
  * following functions:
  * - ::onboard_with_vendor_thing_id,
  * - ::onboard_with_thing_id

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -274,12 +274,12 @@ kii_bool_t init_kii_thing_if(
  * vendor. Must not be NULL and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If the thing is already
- * registered, this value would be ignored by Kii Cloud. If this value
- * is NULL or empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If the
- * thing is already registered, this value would be ignored by Kii
- * Cloud. If this value is NULL or empty string this value is ignored.
+ * @param [in] thing_type Type of the thing. If users specify
+ * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
+ * empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If
+ * users specify firmware_version, this SDK updates firmware version
+ * in Kii Cloud. If NULL or empty string, this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If
@@ -310,12 +310,12 @@ kii_bool_t onboard_with_vendor_thing_id(
  * and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If the thing is already
- * registered, this value would be ignored by Kii Cloud. If this value
- * is NULL or empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If the
- * thing is already registered, this value would be ignored by Kii
- * Cloud. If this value is NULL or empty string this value is ignored.
+ * @param [in] thing_type Type of the thing. If users specify
+ * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
+ * empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If
+ * users specify firmware_version, this SDK updates firmware version
+ * in Kii Cloud. If NULL or empty string, this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -289,12 +289,12 @@ kii_bool_t activate(kii_thing_if_tg* kii_thing_if);
  * vendor. Must not be NULL and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If users specify
- * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
- * empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If
- * users specify firmware_version, this SDK updates firmware version
- * in Kii Cloud. If NULL or empty string, this value is ignored.
+ * @param [in] thing_type Type of the thing. If the thing is already
+ * registered, this value would be ignored by Kii Cloud. If this value
+ * is NULL or empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If the
+ * thing is already registered, this value would be ignored by Kii
+ * Cloud. If this value is NULL or empty string this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If
@@ -325,12 +325,12 @@ kii_bool_t onboard_with_vendor_thing_id(
  * and empty string.
  * @param [in] password Password of the thing given by thing
  * vendor. Must not be NULL and empty string.
- * @param [in] thing_type Type of the thing. If users specify
- * thing_type, this SDK updates thing type in Kii Cloud. If NULL or
- * empty string, this value is ignored.
- * @param [in] firmware_version Firmware version of the thing. If
- * users specify firmware_version, this SDK updates firmware version
- * in Kii Cloud. If NULL or empty string, this value is ignored.
+ * @param [in] thing_type Type of the thing. If the thing is already
+ * registered, this value would be ignored by Kii Cloud. If this value
+ * is NULL or empty string, this value is ignored.
+ * @param [in] firmware_version Firmware version of the thing. If the
+ * thing is already registered, this value would be ignored by Kii
+ * Cloud. If this value is NULL or empty string this value is ignored.
  * @param [in] layout_position Layout position of the thing. Should be
  * one of "STANDALONE", "GATEWAY" or "ENDNODE". If the thing is
  * already registered, this value would be ignored by Kii Cloud. If

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -293,9 +293,13 @@ kii_bool_t init_kii_thing_if(
  * - ::init_kii_thing_if_with_onboarded_thing
  *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
-kii_bool_t start(kii_thing_if_t* kii_thing_if);
+kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
 
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -423,7 +423,8 @@ kii_bool_t update_firmware_version(
  * is called, the returned value might be broken.
  *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return current firmware version. This is null terminated string.
+ * @return current firmware version. Contents of the return value is
+ * one of the followings:
  * - If succeed to get current firmware version, this function
  *   returnes null terminated string denoting firmware version.
  * - If thing does not have firmware version, this function returns


### PR DESCRIPTION
To provide features to update firmware version and thing type for application developers, I propose followings changes:

1. Add `activate()` function. This function starts to receive commands and to update states.
1. Will remove a feature to start to receive commands and to update states from following functions:
   * `onboard_with_vendor_thing_id()`
   * `onboard_with_thing_id()`
   * `init_kii_thing_if_with_onboarded_thing()`
1. Add following 4 functions
   * `update_firmware_version`
   * `get_current_firmware_version`
   * `update_thing_type`
   * `get_current_thing_type`
1. 4 functions in 3 must be called between `activate()` and one of following functions:
   * `onboard_with_vendor_thing_id()`
   * `onboard_with_thing_id()`
   * `init_kii_thing_if_with_onboarded_thing()`

### Why we divide previous onboarding functions to onboarding functions and `activate()` function

We assumed that things update firmware version and thing type before things start to receive commands and to update states because things can know changing of firmware version and thing type with updating the firmware of thing, in other words, reinstalling binary of the thing. As a result, we decided to limit the time of updating them between onboarding and starting to receive commands and to update states.

I conceived following 2 way to update them.

1. Update them in onboarding functions.
1. Divide current onboarding functions to onboarding only funcitons and `activate()` function. Applications update them between new onboarding functions and `activate()` function.

I have proposed 2 beause it is hard for us to know a logic to update firmware version and thing type. It is application dependent. I think we should leave to implement a logic to update them for application developers.


### Snippet
I write a snippet about starting thing-if ThingSDK and updating firmware version and thing type.

```c
// init kii_thing_if instance
if (init_kii_thing_if(&kii_thing_if, EX_APP_ID, EX_APP_KEY, EX_APP_SITE,
                &command_handler_resource, &state_updater_resource, NULL)
        == KII_FALSE) {
    // fail to init.
    return;
}

// onbaord.
if (onboard_with_vendor_thing_id(&kii_thing_if, VENDOR_THING_ID, PASSWORD,
                NULL, NULL, NULL, NULL) == KII_FALSE) {
    // fail to onboard
    return;
}

// get current thing type.
current_type = get_current_thing_type(&kii_thing_if);
if (current_type == NULL) {
    // fail to get thing type.
    return;
}

// is_old_type checks thing type. This is applicatoin dependent.
if (is_old_type(current_type)) {
    // If current_type is old, then update thing type.
    if (update_thing_type(&kii_thing_if, NEW_THING_TYPE) == KII_FALSE) {
        // fail to update thing type.
        return;
    }
}

// get current firmware version.
current_version = get_current_firmware_version(&kii_thing_if);
if (current_version == NULL) {
    // fail to get firmware version.
    return;
}

// is_old_version checks firmware version. This is application dependent.
if (is_old_version(current_version)) {
    // If current_version is old, then update firmware version.
    if (update_firmware_version(&kii_thing_if, NEW_FIRMWARE_VERSION)
            == KII_FALSE) {
        return;
    }
}

// start to received commands and update states
activate(&kii_thing_if);

// run forever.
while(1){}
```

Related PR: #80 
