### PR TITLE
Fix return value of some APIs.

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -779,7 +779,7 @@ static kii_bool_t prv_set_author(
     return KII_TRUE;
 }
 
-kii_bool_t onboard_with_vendor_thing_id(
+kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* vendor_thing_id,
         const char* password,
@@ -790,7 +790,7 @@ kii_bool_t onboard_with_vendor_thing_id(
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);
-    return KII_FALSE;
+    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
     /*
     if (prv_onboard_with_vendor_thing_id(&kii_thing_if->command_handler,
                     vendor_thing_id, password, thing_type,
@@ -880,7 +880,7 @@ static kii_bool_t prv_onboard_with_thing_id(
     return KII_TRUE;
 }
 
-kii_bool_t onboard_with_thing_id(
+kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* thing_id,
         const char* password,
@@ -891,7 +891,7 @@ kii_bool_t onboard_with_thing_id(
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);
-    return KII_FALSE;
+    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
     /*
     if (prv_onboard_with_thing_id(&kii_thing_if->command_handler, thing_id,
                     password) == KII_FALSE) {
@@ -912,7 +912,7 @@ kii_bool_t onboard_with_thing_id(
     */
 }
 
-kii_bool_t init_kii_thing_if_with_onboarded_thing(
+kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_t* kii_thing_if,
         const char* app_id,
         const char* app_key,
@@ -923,6 +923,10 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_state_updater_resource_t* state_updater_resource,
         KII_JSON_RESOURCE_CB resource_cb)
 {
+    // TODO: implement me.
+    M_KII_THING_IF_ASSERT(0);
+    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
+    /*
     if (prv_init_kii_thing_if(kii_thing_if, app_id, app_key, app_host,
                     command_handler_resource, state_updater_resource,
                     resource_cb) == KII_FALSE) {
@@ -950,4 +954,5 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
 
 
     return KII_TRUE;
+    */
 }

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -786,7 +786,8 @@ kii_bool_t onboard_with_vendor_thing_id(
         const char* thing_type,
         const char* firmware_version,
         const char* layout_position,
-        const char* thing_properties)
+        const char* thing_properties,
+        kii_thing_if_error_t* error)
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);
@@ -887,7 +888,8 @@ kii_bool_t onboard_with_thing_id(
         const char* thing_type,
         const char* firmware_version,
         const char* layout_position,
-        const char* thing_properties)
+        const char* thing_properties,
+        kii_thing_if_error_t* error)
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -779,7 +779,7 @@ static kii_bool_t prv_set_author(
     return KII_TRUE;
 }
 
-kii_thing_if_error_t onboard_with_vendor_thing_id(
+kii_bool_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* vendor_thing_id,
         const char* password,
@@ -790,7 +790,7 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);
-    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
+    return KII_FALSE;
     /*
     if (prv_onboard_with_vendor_thing_id(&kii_thing_if->command_handler,
                     vendor_thing_id, password, thing_type,
@@ -880,7 +880,7 @@ static kii_bool_t prv_onboard_with_thing_id(
     return KII_TRUE;
 }
 
-kii_thing_if_error_t onboard_with_thing_id(
+kii_bool_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* thing_id,
         const char* password,
@@ -891,7 +891,7 @@ kii_thing_if_error_t onboard_with_thing_id(
 {
     // TODO: implement me.
     M_KII_THING_IF_ASSERT(0);
-    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
+    return KII_FALSE;
     /*
     if (prv_onboard_with_thing_id(&kii_thing_if->command_handler, thing_id,
                     password) == KII_FALSE) {
@@ -912,7 +912,7 @@ kii_thing_if_error_t onboard_with_thing_id(
     */
 }
 
-kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
+kii_bool_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_t* kii_thing_if,
         const char* app_id,
         const char* app_key,
@@ -923,10 +923,6 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_state_updater_resource_t* state_updater_resource,
         KII_JSON_RESOURCE_CB resource_cb)
 {
-    // TODO: implement me.
-    M_KII_THING_IF_ASSERT(0);
-    return KII_THING_IF_ERROR_TARGET_NOT_FOUND;
-    /*
     if (prv_init_kii_thing_if(kii_thing_if, app_id, app_key, app_host,
                     command_handler_resource, state_updater_resource,
                     resource_cb) == KII_FALSE) {
@@ -954,5 +950,4 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
 
 
     return KII_TRUE;
-    */
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -9,23 +9,41 @@
 extern "C" {
 #endif
 
-/** Enumeration representing error of thing-if ThingSDK. */
+#define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
+
+/** Error reasons of thing-if ThingSDK. */
 typedef enum kii_thing_if_error_reason_t {
-    /** Information trying to get from a function is not found. */
-    KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND,
-    /** Thing is not found in Kii Cloud. */
-    KII_THING_IF_ERROR_REASON_THING_NOT_FOUND,
     /** kii_thing_if_t instance is not onbarded. Please onboard first. */
     KII_THING_IF_ERROR_REASON_NOT_ONBOARDED,
-    /** A buffer size provided from applications is shorter than a
-     * function can copy the information got from Kii Cloud.
-     */
-    KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED,
     /** thing-if ThingSDK is alreday started. */
-    KII_THING_IF_ERROR_REASON_ALREADY_STARTED
+    KII_THING_IF_ERROR_REASON_ALREADY_STARTED,
+    /** HTTP error. */
+    KII_THING_IF_ERROR_REASON_HTTP,
+    /** Socket error. */
+    KII_THING_IF_ERROR_REASON_SOCKET
 } kii_thing_if_error_reason_t;
 
-#define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
+/** Error information of thing-if ThingSDK. */
+typedef struct kii_thing_if_error_t {
+    /** Error reason. */
+    kii_thing_if_error_reason_t reason;
+
+    /** HTTP status code.
+     *
+     * If ::kii_thing_if_error_t::reason is
+     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise,
+     * this value is meaningless.
+     */
+    int http_status_code;
+
+    /** Error code.
+     *
+     * If ::kii_thing_if_error_t::reason is
+     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise,
+     * this value is meaningless.
+     */
+    char http_error_code[32];
+} kii_thing_if_error_t;
 
 /** callback function for handling action.
  * @param [in] alias name of alias.
@@ -298,7 +316,7 @@ kii_bool_t init_kii_thing_if(
  * | :------ | :---------- |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
-kii_thing_if_error_reason_t start(kii_thing_if_t* kii_thing_if);
+kii_bool_t start(kii_thing_if_t* kii_thing_if);
 
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
@@ -430,9 +448,10 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_reason_t update_firmware_version(
+kii_bool_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
-        const char* firmware_version);
+        const char* firmware_version,
+        kii_thing_if_error_t* error);
 
 /** Get firmware version of a thing.
  *
@@ -456,10 +475,11 @@ kii_thing_if_error_reason_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_reason_t get_firmware_version(
+kii_bool_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
         char* firmware_version,
-        size_t firmware_version_len);
+        size_t firmware_version_len,
+        kii_thing_if_error_t* error);
 
 /** Upate thing type of a thing.
  *
@@ -478,9 +498,10 @@ kii_thing_if_error_reason_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_reason_t update_thing_type(
+kii_bool_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
-        const char* thing_type);
+        const char* thing_type,
+        kii_thing_if_error_t* error);
 
 /** Get current thing type of a thing.
  *
@@ -504,10 +525,11 @@ kii_thing_if_error_reason_t update_thing_type(
  * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_reason_t get_thing_type(
+kii_bool_t get_thing_type(
         kii_thing_if_t* kii_thing_if,
         char* thing_type,
-        size_t thing_type_len);
+        size_t thing_type_len,
+        kii_thing_if_error_t* error);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -340,7 +340,11 @@ kii_bool_t start(kii_thing_if_t* kii_thing_if);
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error. This function does not set
+ * ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED to
+ * ::kii_thing_if_error_t::reason.
  */
 kii_bool_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -349,7 +353,8 @@ kii_bool_t onboard_with_vendor_thing_id(
         const char* thing_type,
         const char* firmware_version,
         const char* layout_position,
-        const char* thing_properties);
+        const char* thing_properties,
+        kii_thing_if_error_t* error);
 
 /** Onboard to Thing_If Cloud with specified thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
@@ -376,7 +381,11 @@ kii_bool_t onboard_with_vendor_thing_id(
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error. This function does not set
+ * ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED to
+ * ::kii_thing_if_error_t::reason.
  */
 kii_bool_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -385,7 +394,8 @@ kii_bool_t onboard_with_thing_id(
         const char* thing_type,
         const char* firmware_version,
         const char* layout_position,
-        const char* thing_properties);
+        const char* thing_properties,
+        kii_thing_if_error_t* error);
 
 
 /** Initialize kii_thing_if_t object with onboarded thing information.

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -26,7 +26,16 @@ typedef enum kii_thing_if_error_t {
     /** thing-if ThingSDK is alreday started. */
     KII_THING_IF_ERROR_ALREADY_STARTED,
     /** Length of HTTP request exceeded request buffer. */
-    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
+    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW,
+    /** Socket error.
+     *
+     * Implementation of socket is application dependent. This error
+     * is returned when your socket functions return error. If you
+     * want to know detail of the socket error, you should record the
+     * error in your socket functions. You can record the error with
+     * app_context in kii_http_context_t, external variable and so on.
+     */
+    KII_THING_IF_ERROR_SOCKET
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -338,6 +347,7 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -381,6 +391,7 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -454,6 +465,7 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -481,6 +493,7 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -504,6 +517,7 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -531,6 +545,7 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -311,10 +311,7 @@ kii_bool_t init_kii_thing_if(
  * - ::init_kii_thing_if_with_onboarded_thing
  *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return This function returns following elements of ::kii_thing_if_error_reason_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
 kii_bool_t start(kii_thing_if_t* kii_thing_if);
 
@@ -441,12 +438,11 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] firmware_version firmware version to update.
- * @return This function returns following elements of ::kii_thing_if_error_reason_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * @param [out] error Error infomation. If NULL, This SDK does not
+ * return error information
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error.
  */
 kii_bool_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -466,14 +462,11 @@ kii_bool_t update_firmware_version(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] firmware_version_len length of firmware_version which
  * is second argument of this function.
- * @return This function returns following elements of ::kii_thing_if_error_reason_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no firmware version. |
- * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
- * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * @param [out] error Error infomation. If NULL, This SDK does not
+ * return error information
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error.
  */
 kii_bool_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -491,12 +484,11 @@ kii_bool_t get_firmware_version(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] thing_type thing type to update.
- * @return This function returns following elements of ::kii_thing_if_error_reason_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * @param [out] error Error infomation. If NULL, This SDK does not
+ * return error information
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error.
  */
 kii_bool_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -516,14 +508,11 @@ kii_bool_t update_thing_type(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] thing_type_len length of thing_type which
  * is second argument of this function.
- * @return This function returns following elements of ::kii_thing_if_error_reason_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no thing type. |
- * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
- * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * @param [out] error Error infomation. If NULL, This SDK does not
+ * return error information
+ * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
+ * value is KII_FALSE and error is not NULL, this SDK set error
+ * information to the error.
  */
 kii_bool_t get_thing_type(
         kii_thing_if_t* kii_thing_if,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -39,7 +39,7 @@ typedef struct kii_thing_if_error_t {
      *
      * If ::kii_thing_if_error_t::reason is
      * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise
-     * empty string.
+     * functions does not change this value.
      */
     char error_code[64];
 } kii_thing_if_error_t;

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -10,22 +10,22 @@ extern "C" {
 #endif
 
 /** Enumeration representing error of thing-if ThingSDK. */
-typedef enum kii_thing_if_error_t {
+typedef enum kii_thing_if_error_reason_t {
     /** Functions succeed. There is no error. */
-    KII_THING_IF_ERROR_NO_ERROR = 0,
+    KII_THING_IF_ERROR_REASON_NO_ERROR = 0,
     /** Information trying to get from a function is not found. */
-    KII_THING_IF_ERROR_TARGET_NOT_FOUND,
+    KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND,
     /** Thing is not found in Kii Cloud. */
-    KII_THING_IF_ERROR_THING_NOT_FOUND,
+    KII_THING_IF_ERROR_REASON_THING_NOT_FOUND,
     /** kii_thing_if_t instance is not onbarded. Please onboard first. */
-    KII_THING_IF_ERROR_NOT_ONBOARDED,
+    KII_THING_IF_ERROR_REASON_NOT_ONBOARDED,
     /** A buffer size provided from applications is shorter than a
      * function can copy the information got from Kii Cloud.
      */
-    KII_THING_IF_ERROR_LENGTH_EXCEEDED,
+    KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED,
     /** thing-if ThingSDK is alreday started. */
-    KII_THING_IF_ERROR_ALREADY_STARTED
-} kii_thing_if_error_t;
+    KII_THING_IF_ERROR_REASON_ALREADY_STARTED
+} kii_thing_if_error_reason_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
 
@@ -295,13 +295,13 @@ kii_bool_t init_kii_thing_if(
  * - ::init_kii_thing_if_with_onboarded_thing
  *
  * @param [in] kii_thing_if_t This SDK instance.
- * @return This function returns following elements of ::kii_thing_if_error_t:
+ * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
-kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
+kii_thing_if_error_reason_t start(kii_thing_if_t* kii_thing_if);
 
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
@@ -426,15 +426,15 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] firmware_version firmware version to update.
- * @return This function returns following elements of ::kii_thing_if_error_t:
+ * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_t update_firmware_version(
+kii_thing_if_error_reason_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
         const char* firmware_version);
 
@@ -451,17 +451,17 @@ kii_thing_if_error_t update_firmware_version(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] firmware_version_len length of firmware_version which
  * is second argument of this function.
- * @return This function returns following elements of ::kii_thing_if_error_t:
+ * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_TARGET_NOT_FOUND | Thing has no firmware version. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no firmware version. |
+ * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
+ * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_t get_firmware_version(
+kii_thing_if_error_reason_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
         char* firmware_version,
         size_t firmware_version_len);
@@ -476,15 +476,15 @@ kii_thing_if_error_t get_firmware_version(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] thing_type thing type to update.
- * @return This function returns following elements of ::kii_thing_if_error_t:
+ * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_t update_thing_type(
+kii_thing_if_error_reason_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
         const char* thing_type);
 
@@ -501,17 +501,17 @@ kii_thing_if_error_t update_thing_type(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] thing_type_len length of thing_type which
  * is second argument of this function.
- * @return This function returns following elements of ::kii_thing_if_error_t:
+ * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_TARGET_NOT_FOUND | Thing has no thing type. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no thing type. |
+ * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_REASON_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
+ * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
  */
-kii_thing_if_error_t get_thing_type(
+kii_thing_if_error_reason_t get_thing_type(
         kii_thing_if_t* kii_thing_if,
         char* thing_type,
         size_t thing_type_len);

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -11,8 +11,6 @@ extern "C" {
 
 /** Enumeration representing error of thing-if ThingSDK. */
 typedef enum kii_thing_if_error_reason_t {
-    /** Functions succeed. There is no error. */
-    KII_THING_IF_ERROR_REASON_NO_ERROR = 0,
     /** Information trying to get from a function is not found. */
     KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND,
     /** Thing is not found in Kii Cloud. */
@@ -298,7 +296,6 @@ kii_bool_t init_kii_thing_if(
  * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  */
 kii_thing_if_error_reason_t start(kii_thing_if_t* kii_thing_if);
@@ -429,7 +426,6 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
@@ -454,7 +450,6 @@ kii_thing_if_error_reason_t update_firmware_version(
  * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no firmware version. |
  * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
@@ -479,7 +474,6 @@ kii_thing_if_error_reason_t get_firmware_version(
  * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_REASON_ALREADY_STARTED | thing-if ThingSDK is already started.|
@@ -504,7 +498,6 @@ kii_thing_if_error_reason_t update_thing_type(
  * @return This function returns following elements of ::kii_thing_if_error_reason_t:
  * | Element | Description |
  * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_REASON_NO_ERROR | execution succeed. |
  * | ::KII_THING_IF_ERROR_REASON_TARGET_NOT_FOUND | Thing has no thing type. |
  * | ::KII_THING_IF_ERROR_REASON_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_REASON_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -448,8 +448,8 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] firmware_version firmware version to update.
- * @param [out] error Error infomation. If NULL, This SDK does not
- * return error information
+ * @param [out] error Error infomation. This is optional. If NULL,
+ * error information is not set.
  * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
  * value is KII_FALSE and error is not NULL, this SDK set error
  * information to the error.
@@ -472,8 +472,8 @@ kii_bool_t update_firmware_version(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] firmware_version_len length of firmware_version which
  * is second argument of this function.
- * @param [out] error Error infomation. If NULL, This SDK does not
- * return error information
+ * @param [out] error Error infomation. This is optional. If NULL,
+ * error information is not set.
  * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
  * value is KII_FALSE and error is not NULL, this SDK set error
  * information to the error.
@@ -494,8 +494,8 @@ kii_bool_t get_firmware_version(
  *
  * @param [in] kii_thing_if_t This SDK instance.
  * @param [in] thing_type thing type to update.
- * @param [out] error Error infomation. If NULL, This SDK does not
- * return error information
+ * @param [out] error Error infomation. This is optional. If NULL,
+ * error information is not set.
  * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
  * value is KII_FALSE and error is not NULL, this SDK set error
  * information to the error.
@@ -518,8 +518,8 @@ kii_bool_t update_thing_type(
  * from Kii Cloud. This SDK makes the buffer null terminated string.
  * @param [in] thing_type_len length of thing_type which
  * is second argument of this function.
- * @param [out] error Error infomation. If NULL, This SDK does not
- * return error information
+ * @param [out] error Error infomation. This is optional. If NULL,
+ * error information is not set.
  * @return KII_TRUE when succeeded, KII_FALSE when failed. If returned
  * value is KII_FALSE and error is not NULL, this SDK set error
  * information to the error.

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -24,7 +24,9 @@ typedef enum kii_thing_if_error_t {
      */
     KII_THING_IF_ERROR_LENGTH_EXCEEDED,
     /** thing-if ThingSDK is alreday started. */
-    KII_THING_IF_ERROR_ALREADY_STARTED
+    KII_THING_IF_ERROR_ALREADY_STARTED,
+    /** Length of HTTP request exceeded request buffer. */
+    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -328,9 +330,16 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
  */
-kii_bool_t onboard_with_vendor_thing_id(
+kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* vendor_thing_id,
         const char* password,
@@ -364,9 +373,16 @@ kii_bool_t onboard_with_vendor_thing_id(
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
  */
-kii_bool_t onboard_with_thing_id(
+kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* thing_id,
         const char* password,
@@ -403,9 +419,14 @@ kii_bool_t onboard_with_thing_id(
  * argument. otherwise, you need to set kii_json_resource_t object to
  * this argument.
  *
- * @return KII_TRUE when succeeded, KII_FALSE when failed.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
  */
-kii_bool_t init_kii_thing_if_with_onboarded_thing(
+kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_t* kii_thing_if,
         const char* app_id,
         const char* app_key,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -31,16 +31,15 @@ typedef struct kii_thing_if_error_t {
     /** HTTP status code.
      *
      * If ::kii_thing_if_error_t::reason is
-     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise,
-     * this value is meaningless.
+     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise -1.
      */
     int http_status_code;
 
     /** Error code.
      *
      * If ::kii_thing_if_error_t::reason is
-     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise,
-     * this value is meaningless.
+     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise
+     * empty string.
      */
     char error_code[64];
 } kii_thing_if_error_t;

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -42,7 +42,7 @@ typedef struct kii_thing_if_error_t {
      * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise,
      * this value is meaningless.
      */
-    char http_error_code[32];
+    char error_code[64];
 } kii_thing_if_error_t;
 
 /** callback function for handling action.

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -31,7 +31,7 @@ typedef struct kii_thing_if_error_t {
     /** HTTP status code.
      *
      * If ::kii_thing_if_error_t::reason is
-     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise -1.
+     * ::KII_THING_IF_ERROR_REASON_HTTP, this value is set. Otherwise 0.
      */
     int http_status_code;
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -24,9 +24,7 @@ typedef enum kii_thing_if_error_t {
      */
     KII_THING_IF_ERROR_LENGTH_EXCEEDED,
     /** thing-if ThingSDK is alreday started. */
-    KII_THING_IF_ERROR_ALREADY_STARTED,
-    /** Length of HTTP request exceeded request buffer. */
-    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
+    KII_THING_IF_ERROR_ALREADY_STARTED
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -330,16 +328,9 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return This function returns following elements of ::kii_thing_if_error_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
-kii_thing_if_error_t onboard_with_vendor_thing_id(
+kii_bool_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* vendor_thing_id,
         const char* password,
@@ -373,16 +364,9 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * the format. If the thing is already registered, this value would be
  * ignored by Kii Cloud. If this value is NULL or empty string this
  * value is ignored.
- * @return This function returns following elements of ::kii_thing_if_error_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
-kii_thing_if_error_t onboard_with_thing_id(
+kii_bool_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
         const char* thing_id,
         const char* password,
@@ -419,14 +403,9 @@ kii_thing_if_error_t onboard_with_thing_id(
  * argument. otherwise, you need to set kii_json_resource_t object to
  * this argument.
  *
- * @return This function returns following elements of ::kii_thing_if_error_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
-kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
+kii_bool_t init_kii_thing_if_with_onboarded_thing(
         kii_thing_if_t* kii_thing_if,
         const char* app_id,
         const char* app_key,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -26,16 +26,7 @@ typedef enum kii_thing_if_error_t {
     /** thing-if ThingSDK is alreday started. */
     KII_THING_IF_ERROR_ALREADY_STARTED,
     /** Length of HTTP request exceeded request buffer. */
-    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW,
-    /** Socket error.
-     *
-     * Implementation of socket is application dependent. This error
-     * is returned when your socket functions return error. If you
-     * want to know detail of the socket error, you should record the
-     * error in your socket functions. You can record the error with
-     * app_context in kii_http_context_t, external variable and so on.
-     */
-    KII_THING_IF_ERROR_SOCKET
+    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -347,7 +338,6 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -391,7 +381,6 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -465,7 +454,6 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -493,7 +481,6 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -517,7 +504,6 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -545,7 +531,6 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,


### PR DESCRIPTION
We introduced `kii_thing_if_error_t` in #87 . APIs use this as return value.

We fixed type of return value of some existing APIs to `kii_thing_if_error_t`. Fixed APIs are followings:

* `onboard_with_vendor_thing_id()`
* `onboard_with_thing_id()`
* `init_kii_thing_if_with_onboarded_thing()`

Above APIs must fails with various reasons so I changed type of return value.

On the other hand, I remained type of return value of 5 existing APIs. 4 APIs are callback handler, the last API is initializer of `kii_thing_if_t`.

The reason not to change type of return value for 4 callback handler is that we can not do anything if we get detail of failure of callback.

Initializer of `kii_thing_if_t` is not faild so we do not do anything.

Related PR: #80 