### PR TITLE
Add get_http_error_info.

### DIFF
--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -28,16 +28,7 @@ typedef enum kii_thing_if_error_t {
     /** Length of HTTP request exceeded request buffer. */
     KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW,
     /** Http error. */
-    KII_THING_IF_ERROR_HTTP,
-    /** Socket error.
-     *
-     * Implementation of socket is application dependent. This error
-     * is returned when your socket functions return error. If you
-     * want to know detail of the socket error, you should record the
-     * error in your socket functions. You can record the error with
-     * app_context in kii_http_context_t, external variable and so on.
-     */
-    KII_THING_IF_ERROR_SOCKET
+    KII_THING_IF_ERROR_HTTP
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -350,7 +341,6 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -395,7 +385,6 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -470,7 +459,6 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -499,7 +487,6 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -524,7 +511,6 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -553,7 +539,6 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
- * : ::KII_THING_IF_ERROR_SOCKET | Socket error. |
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -582,7 +582,7 @@ kii_thing_if_error_t get_http_error_info(
         char* error_code,
         size_t* error_code_len,
         char* error_detail,
-        size_t* error_detail_len);
+        size_t* error_detail_len)
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -582,7 +582,7 @@ kii_thing_if_error_t get_http_error_info(
         char* error_code,
         size_t* error_code_len,
         char* error_detail,
-        size_t* error_detail_len)
+        size_t* error_detail_len);
 
 #ifdef __cplusplus
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -26,7 +26,9 @@ typedef enum kii_thing_if_error_t {
     /** thing-if ThingSDK is alreday started. */
     KII_THING_IF_ERROR_ALREADY_STARTED,
     /** Length of HTTP request exceeded request buffer. */
-    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
+    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW,
+    /** Http error. */
+    KII_THING_IF_ERROR_HTTP
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -338,6 +340,7 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -381,6 +384,7 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -454,6 +458,7 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -481,6 +486,7 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -504,6 +510,7 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -531,15 +538,54 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
+ * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,
         char* thing_type,
         size_t thing_type_len);
 
+/** Get HTTP error information detail.
+ *
+ * You can get detail of HTTP error from this functions. If you got
+ * ::KII_THING_IF_ERROR_HTTP from a function, then you can use this
+ * functions. SDK leaves HTTP error information until other function
+ * is called. You need to call this function right after a function
+ * returns ::KII_THING_IF_ERROR_HTTP if you want to check the detail.
+ *
+ * @param [in] kii_thing_if_t This SDK instance.
+ * @param [out] status_code HTTP status code
+ * @param [out] error_code Kii Cloud defined error code. This SDK
+ * makes this string null terminated. If there is no error code or,
+ * Length of error_code is shorter than required, This SDK set empty
+ * string.
+ * @param [inout] error_code_len Length of error_code which is thrid
+ * argument of this function. If this length is shorter than required,
+ * This SDK set actual required length.
+ * @param [out] error_detail Kii Cloud defined error detail. This SDK
+ * makes this string null terminated. If there is no error detail or,
+ * Length of error_detail is shorter than required, This SDK set empty
+ * string.
+ * @param [inout] error_detail_len Length of error_detail which is
+ * fifth argument of this function. If this length is shorter than
+ * required, This SDK set actual required length.
+ * @return This function returns following elements of ::kii_thing_if_error_t:
+ * | Element | Description |
+ * | :------ | :---------- |
+ * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
+ * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
+ * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of error code or error detail exceed by error_code_len or error_detail_len. |
+ */
+kii_thing_if_error_t get_http_error_info(
+        kii_thing_if_t* kii_thing_if,
+        int* status_code,
+        char* error_code,
+        size_t* error_code_len,
+        char* error_detail,
+        size_t* error_detail_len)
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _KII_THING_IF_ */
-

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -26,9 +26,7 @@ typedef enum kii_thing_if_error_t {
     /** thing-if ThingSDK is alreday started. */
     KII_THING_IF_ERROR_ALREADY_STARTED,
     /** Length of HTTP request exceeded request buffer. */
-    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW,
-    /** Http error. */
-    KII_THING_IF_ERROR_HTTP
+    KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW
 } kii_thing_if_error_t;
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
@@ -340,7 +338,6 @@ kii_thing_if_error_t start(kii_thing_if_t* kii_thing_if);
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_ERROR_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t onboard_with_vendor_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -384,7 +381,6 @@ kii_thing_if_error_t onboard_with_vendor_thing_id(
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
  * | ::KII_THING_IF_REQUEST_BUFFER_OVER_FLOW | Request buffer is small to send request. |
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of access token exceed. |
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t onboard_with_thing_id(
         kii_thing_if_t* kii_thing_if,
@@ -458,7 +454,6 @@ kii_thing_if_error_t init_kii_thing_if_with_onboarded_thing(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t update_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -486,7 +481,6 @@ kii_thing_if_error_t update_firmware_version(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of firmware version exceed by firmware_version_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t get_firmware_version(
         kii_thing_if_t* kii_thing_if,
@@ -510,7 +504,6 @@ kii_thing_if_error_t get_firmware_version(
  * | ::KII_THING_IF_ERROR_THING_NOT_FOUND | There is no thing in Kii Cloud. |
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t update_thing_type(
         kii_thing_if_t* kii_thing_if,
@@ -538,54 +531,15 @@ kii_thing_if_error_t update_thing_type(
  * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
  * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of thing type exceed by thing_type_len. |
  * | ::KII_THING_IF_ERROR_ALREADY_STARTED | thing-if ThingSDK is already started.|
- * | ::KII_THING_IF_ERROR_HTTP | HTTP error. You can retrieve detail information about HTTP error with ::get_http_error_info|
  */
 kii_thing_if_error_t get_thing_type(
         kii_thing_if_t* kii_thing_if,
         char* thing_type,
         size_t thing_type_len);
 
-/** Get HTTP error information detail.
- *
- * You can get detail of HTTP error from this functions. If you got
- * ::KII_THING_IF_ERROR_HTTP from a function, then you can use this
- * functions. SDK leaves HTTP error information until other function
- * is called. You need to call this function right after a function
- * returns ::KII_THING_IF_ERROR_HTTP if you want to check the detail.
- *
- * @param [in] kii_thing_if_t This SDK instance.
- * @param [out] status_code HTTP status code
- * @param [out] error_code Kii Cloud defined error code. This SDK
- * makes this string null terminated. If there is no error code or,
- * Length of error_code is shorter than required, This SDK set empty
- * string.
- * @param [inout] error_code_len Length of error_code which is thrid
- * argument of this function. If this length is shorter than required,
- * This SDK set actual required length.
- * @param [out] error_detail Kii Cloud defined error detail. This SDK
- * makes this string null terminated. If there is no error detail or,
- * Length of error_detail is shorter than required, This SDK set empty
- * string.
- * @param [inout] error_detail_len Length of error_detail which is
- * fifth argument of this function. If this length is shorter than
- * required, This SDK set actual required length.
- * @return This function returns following elements of ::kii_thing_if_error_t:
- * | Element | Description |
- * | :------ | :---------- |
- * | ::KII_THING_IF_ERROR_NO_ERROR | execution succeed. |
- * | ::KII_THING_IF_ERROR_NOT_ONBOARDED | Thing is not onboarded. Please onboard first.|
- * | ::KII_THING_IF_ERROR_LENGTH_EXCEEDED | Length of error code or error detail exceed by error_code_len or error_detail_len. |
- */
-kii_thing_if_error_t get_http_error_info(
-        kii_thing_if_t* kii_thing_if,
-        int* status_code,
-        char* error_code,
-        size_t* error_code_len,
-        char* error_detail,
-        size_t* error_detail_len)
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _KII_THING_IF_ */
+


### PR DESCRIPTION
This is a part of error definition PR #88.

To represent HTTP error, I added `kii_thing_if_error_t#KII_THING_IF_ERROR_HTTP` and `get_http_error_info()`.

If applications get `kii_thing_if_error_t#KII_THING_IF_ERROR_HTTP`, applications can know detail of the error by calling `get_http_error_info()`

`get_http_error_info()` returns:

* HTTP status code
* Error code
* Error detail message

If we define all server errors respectively as elements of `kii_thing_if_error_t`, Number of the elements becomes large. it might be hard for us to maintain them. This is similar to thing-if iOSSDK's [ThingIFError.errorResponse](https://github.com/KiiPlatform/thing-if-iOSSDK/blob/d9b227e46a481f794fdf6c5620ca403020fdb787/ThingIFSDK/ThingIFSDK/ThingIFError.swift#L27).

Related PR: #88 