### PR TITLE
Implement onboard with vendor thing ID

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -702,7 +702,9 @@ static void received_callback(kii_t* kii, char* buffer, size_t buffer_size) {
     }
 }
 
-static int prv_kii_thing_if_get_anonymous_token(kii_t* kii)
+static int prv_kii_thing_if_get_anonymous_token(
+        kii_t* kii,
+        kii_thing_if_error_t* error)
 {
     char resource_path[64];
     kii_json_field_t fields[2];
@@ -781,11 +783,12 @@ static kii_bool_t prv_onboard_with_vendor_thing_id(
         const char* thing_type,
         const char* thing_properties,
         const char* firmware_version,
-        const char* layout_position)
+        const char* layout_position,
+        kii_thing_if_error_t* error)
 {
     char resource_path[64];
 
-    if (prv_kii_thing_if_get_anonymous_token(kii) != 0) {
+    if (prv_kii_thing_if_get_anonymous_token(kii, error) != 0) {
         M_KII_LOG(kii->kii_core.logger_cb("fail to get anonymous token.\n"));
         return KII_FALSE;
     }
@@ -931,7 +934,7 @@ kii_bool_t onboard_with_vendor_thing_id(
 
     if (prv_onboard_with_vendor_thing_id(&kii_thing_if->command_handler,
                     vendor_thing_id, password, thing_type,
-                    thing_properties, firmware_version, layout_position)
+                    thing_properties, firmware_version, layout_position, error)
             == KII_FALSE) {
         return KII_FALSE;
     }
@@ -958,6 +961,9 @@ static kii_bool_t prv_onboard_with_thing_id(
         const char* layout_position)
 
 {
+    // TODO: implement me.
+    /*
+
     char resource_path[64];
 
     if (prv_kii_thing_if_get_anonymous_token(kii) != 0) {
@@ -980,13 +986,17 @@ static kii_bool_t prv_onboard_with_thing_id(
         M_KII_LOG(kii->kii_core.logger_cb(
             "fail to start api call.\n"));
     }
+    */
 
     /* Open to write JSON object. */
+    /*
     if (kii_api_call_append_body(kii, "{", CONST_STRLEN("{")) != 0) {
         M_KII_LOG(kii->kii_core.logger_cb("request size overflowed.\n"));
         return KII_FALSE;
     }
+    */
     /* Append key value pairs. */
+    /*
     if (prv_append_key_value_string(kii, "thingID", thing_id, FALSE) != 0 ||
             prv_append_key_value_string(
                 kii, "thingPassword", password, TRUE) != 0 ||
@@ -1001,7 +1011,9 @@ static kii_bool_t prv_onboard_with_thing_id(
         M_KII_LOG(kii->kii_core.logger_cb("request size overflowed.\n"));
         return KII_FALSE;
     }
+    */
     /* Close JSON object. */
+    /*
     if (kii_api_call_append_body(kii, "}", CONST_STRLEN("}")) != 0) {
         M_KII_LOG(kii->kii_core.logger_cb("request size overflowed.\n"));
         return KII_FALSE;
@@ -1020,6 +1032,7 @@ static kii_bool_t prv_onboard_with_thing_id(
     if (kii_push_start_routine(kii, received_callback) != 0) {
         return KII_FALSE;
     }
+    */
 
     return KII_TRUE;
 }

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -922,6 +922,13 @@ kii_bool_t onboard_with_vendor_thing_id(
         const char* thing_properties,
         kii_thing_if_error_t* error)
 {
+    if (kii_thing_if->is_started == KII_TRUE) {
+        if (error != NULL) {
+            error->reason = KII_THING_IF_ERROR_REASON_ALREADY_STARTED;
+        }
+        return KII_FALSE;
+    }
+
     if (prv_onboard_with_vendor_thing_id(&kii_thing_if->command_handler,
                     vendor_thing_id, password, thing_type,
                     thing_properties, firmware_version, layout_position)
@@ -935,6 +942,8 @@ kii_bool_t onboard_with_vendor_thing_id(
             == KII_FALSE) {
         return KII_FALSE;
     }
+
+    kii_thing_if->is_started = KII_TRUE;
 
     return KII_TRUE;
 }

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -199,8 +199,8 @@ static prv_bool_t prv_execute_http_session(
     }
 
     /* check http status */
-    if (kii->kii_core.response_code >= 200 &&
-            kii->kii_core.response_code < 300) {
+    if (kii->kii_core.response_code < 200 ||
+            kii->kii_core.response_code >= 300) {
         if (error != NULL) {
             kii_json_field_t fields[2];
             memset(fields, 0x00, sizeof(fields));

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -309,6 +309,8 @@ static kii_bool_t prv_init_kii_thing_if(
     kii_thing_if->state_updater.delay_ms_cb = delay_ms_cb_impl;
     kii_thing_if->state_updater.kii_core.logger_cb = logger_cb_impl;
 
+    kii_thing_if->is_started = KII_FALSE;
+
     return KII_TRUE;
 }
 

--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -842,11 +842,6 @@ static kii_bool_t prv_onboard_with_vendor_thing_id(
         return KII_FALSE;
     }
 
-    if (kii_push_start_routine(kii, received_callback) != 0) {
-        M_KII_LOG(kii->kii_core.logger_cb("fail to start routine.\n"));
-        return KII_FALSE;
-    }
-
     return KII_TRUE;
 }
 
@@ -940,9 +935,6 @@ kii_bool_t onboard_with_vendor_thing_id(
             == KII_FALSE) {
         return KII_FALSE;
     }
-    kii_thing_if->state_updater.task_create_cb(
-            KII_THING_IF_TASK_NAME_STATUS_UPDATE,
-            prv_update_status, (void*)&kii_thing_if->state_updater);
 
     return KII_TRUE;
 }

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -266,6 +266,8 @@ typedef struct kii_thing_if_t {
     KII_THING_IF_CUSTOM_PUSH_HANDLER custom_push_handler;
     /** Specify the period of updating state in seconds. */
     int state_update_period;
+    /** Represent kii_thing_if_t is started or not. */
+    kii_bool_t is_started;
 } kii_thing_if_t;
 
 /** Initialize kii_thing_if_t object.

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -270,7 +270,11 @@ typedef struct kii_thing_if_t {
     KII_THING_IF_CUSTOM_PUSH_HANDLER custom_push_handler;
     /** Specify the period of updating state in seconds. */
     int state_update_period;
-    /** Represent kii_thing_if_t is started or not. */
+
+    /**
+     * Represent kii_thing_if_t is started or not. Application must
+     * not change this value.
+     */
     kii_bool_t is_started;
 } kii_thing_if_t;
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -20,7 +20,9 @@ typedef enum kii_thing_if_error_reason_t {
     /** HTTP error. */
     KII_THING_IF_ERROR_REASON_HTTP,
     /** Socket error. */
-    KII_THING_IF_ERROR_REASON_SOCKET
+    KII_THING_IF_ERROR_REASON_SOCKET,
+    /** HTTP buffer overflow. */
+    KII_THING_IF_ERROR_REASON_REQUEST_BUFFER_OVERFLOW
 } kii_thing_if_error_reason_t;
 
 /** Error information of thing-if ThingSDK. */

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -22,7 +22,9 @@ typedef enum kii_thing_if_error_reason_t {
     /** Socket error. */
     KII_THING_IF_ERROR_REASON_SOCKET,
     /** HTTP buffer overflow. */
-    KII_THING_IF_ERROR_REASON_REQUEST_BUFFER_OVERFLOW
+    KII_THING_IF_ERROR_REASON_REQUEST_BUFFER_OVERFLOW,
+    /** Fail to parse HTTP response. */
+    KII_THING_IF_ERROR_REASON_PARSE_RESPONSE
 } kii_thing_if_error_reason_t;
 
 /** Error information of thing-if ThingSDK. */

--- a/linux-sample/example.c
+++ b/linux-sample/example.c
@@ -79,97 +79,23 @@ static kii_bool_t prv_set_smartlight_info(const prv_smartlight_t* smartlight)
 }
 
 static kii_bool_t action_handler(
-        const char* schema,
-        int schema_version,
+        const char* alias,
         const char* action_name,
         const char* action_params,
         char error[EMESSAGE_SIZE + 1])
 {
     prv_smartlight_t smartlight;
 
-    printf("schema=%s, schema_version=%d, action name=%s, action params=%s\n",
-            schema, schema_version, action_name, action_params);
+    printf("alias=%s, action name=%s, action params=%s\n",
+            alias, action_name, action_params);
 
-    if (strcmp(schema, "SmartLight-Demo") != 0 || schema_version != 1) {
-        printf("invalid schema: %s %d\n", schema, schema_version);
-        snprintf(error, EMESSAGE_SIZE + 1, "invalid schema: %s %d",
-                schema, schema_version);
+    if (strcmp(alias, "AirConditionerAlias") != 0 ||
+            strcmp(alias, "HumidityAlias") != 0) {
+        snprintf(error, EMESSAGE_SIZE + 1, "invalid alias: %s", alias);
         return KII_FALSE;
     }
 
-    memset(&smartlight, 0x00, sizeof(smartlight));
-    if (prv_get_smartlight_info(&smartlight) == KII_FALSE) {
-        printf("fail to lock.\n");
-        strcpy(error, "fail to lock.");
-        return KII_FALSE;
-    }
-    if (strcmp(action_name, "turnPower") == 0) {
-        kii_json_field_t fields[2];
-
-        memset(fields, 0x00, sizeof(fields));
-        fields[0].path = "/power";
-        fields[0].type = KII_JSON_FIELD_TYPE_BOOLEAN;
-        fields[1].path = NULL;
-        if(prv_json_read_object(action_params, strlen(action_params),
-                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
-            printf("invalid turnPower json\n");
-            return KII_FALSE;
-        }
-        smartlight.power = fields[0].field_copy.boolean_value;
-    } else if (strcmp(action_name, "setBrightness") == 0) {
-        kii_json_field_t fields[2];
-
-        memset(fields, 0x00, sizeof(fields));
-        fields[0].path = "/brightness";
-        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
-        fields[1].path = NULL;
-        if(prv_json_read_object(action_params, strlen(action_params),
-                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
-            printf("invalid brightness json\n");
-            return KII_FALSE;
-        }
-        smartlight.brightness = fields[0].field_copy.int_value;
-    } else if (strcmp(action_name, "setColor") == 0) {
-        kii_json_field_t fields[4];
-
-        memset(fields, 0x00, sizeof(fields));
-        fields[0].path = "/color/[0]";
-        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
-        fields[1].path = "/color/[1]";
-        fields[1].type = KII_JSON_FIELD_TYPE_INTEGER;
-        fields[2].path = "/color/[2]";
-        fields[2].type = KII_JSON_FIELD_TYPE_INTEGER;
-        fields[3].path = NULL;
-        if(prv_json_read_object(action_params, strlen(action_params),
-                         fields, error) !=  KII_JSON_PARSE_SUCCESS) {
-            printf("invalid color json\n");
-            return KII_FALSE;
-        }
-        smartlight.color[0] = fields[0].field_copy.int_value;
-        smartlight.color[1] = fields[1].field_copy.int_value;
-        smartlight.color[2] = fields[2].field_copy.int_value;
-    } else if (strcmp(action_name, "setColorTemperature") == 0) {
-        kii_json_field_t fields[2];
-
-        memset(fields, 0x00, sizeof(fields));
-        fields[0].path = "/colorTemperature";
-        fields[0].type = KII_JSON_FIELD_TYPE_INTEGER;
-        fields[1].path = NULL;
-        if(prv_json_read_object(action_params, strlen(action_params),
-                        fields, error) !=  KII_JSON_PARSE_SUCCESS) {
-            printf("invalid colorTemperature json\n");
-            return KII_FALSE;
-        }
-        smartlight.color_temperature = fields[0].field_copy.int_value;
-    } else {
-        printf("invalid action: %s\n", action_name);
-        return KII_FALSE;
-    }
-
-    if (prv_set_smartlight_info(&smartlight) == KII_FALSE) {
-        printf("fail to unlock.\n");
-        return KII_FALSE;
-    }
+    // TODO: implement me.
     return KII_TRUE;
 }
 
@@ -394,11 +320,25 @@ int main(int argc, char** argv)
                     exit(1);
                 }
                 if (vendorThingID != NULL) {
-                    result = onboard_with_vendor_thing_id(&kii_thing_if, vendorThingID,
-                            password, NULL, NULL, NULL, NULL);
+                    result = onboard_with_vendor_thing_id(
+                            &kii_thing_if,
+                            vendorThingID,
+                            password,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL);
                 } else {
-                    result = onboard_with_thing_id(&kii_thing_if, thingID,
-                            password, NULL, NULL, NULL, NULL);
+                    result = onboard_with_thing_id(
+                            &kii_thing_if,
+                            thingID,
+                            password,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL);
                 }
                 if (result == KII_FALSE) {
                     printf("failed to onboard.\n");


### PR DESCRIPTION
* Implement `onboard_with_vendor_thing_id` function.
* Add new error reason
  * `KII_THING_IF_ERROR_REASON_REQUEST_BUFFER_OVERFLOW` represents request buffer overflow.
  * `KII_THING_IF_ERROR_REASON_PARSE_RESPONSE` represents fail to parse response.
* Add new field to `kii_thing_if_t`.
  * `is_started` represents `kii_thing_if_t` instance is already started or not.

I ignored to adapt `KII_THING_IF_ERROR_REASON_SOCKET` error because we might require to fix KiiThingSDK and KiiThingSDK-Core. I will fix it in another PR.

Related PR: #81 