### PR TITLE
Replace is_started to state.

### DIFF
--- a/kii_thing_if.c
+++ b/kii_thing_if.c
@@ -356,7 +356,7 @@ static kii_bool_t prv_init_kii_thing_if(
     kii_thing_if->state_updater.delay_ms_cb = delay_ms_cb_impl;
     kii_thing_if->state_updater.kii_core.logger_cb = logger_cb_impl;
 
-    kii_thing_if->is_started = KII_FALSE;
+    kii_thing_if->state = KII_THING_IF_STATE_INITIALIZED;
 
     return KII_TRUE;
 }
@@ -972,7 +972,7 @@ kii_bool_t onboard_with_vendor_thing_id(
         const char* thing_properties,
         kii_thing_if_error_t* error)
 {
-    if (kii_thing_if->is_started == KII_TRUE) {
+    if (kii_thing_if->state == KII_THING_IF_STATE_STARTED) {
         if (error != NULL) {
             error->reason = KII_THING_IF_ERROR_REASON_ALREADY_STARTED;
         }
@@ -993,7 +993,7 @@ kii_bool_t onboard_with_vendor_thing_id(
         return KII_FALSE;
     }
 
-    kii_thing_if->is_started = KII_TRUE;
+    kii_thing_if->state = KII_THING_IF_STATE_ONBOARDED;
 
     return KII_TRUE;
 }
@@ -1072,7 +1072,7 @@ kii_bool_t onboard_with_thing_id(
         const char* thing_properties,
         kii_thing_if_error_t* error)
 {
-    if (kii_thing_if->is_started == KII_TRUE) {
+    if (kii_thing_if->state == KII_THING_IF_STATE_STARTED) {
         if (error != NULL) {
             error->reason = KII_THING_IF_ERROR_REASON_ALREADY_STARTED;
         }
@@ -1092,7 +1092,7 @@ kii_bool_t onboard_with_thing_id(
         return KII_FALSE;
     }
 
-    kii_thing_if->is_started = KII_TRUE;
+    kii_thing_if->state = KII_THING_IF_STATE_ONBOARDED;
 
     return KII_TRUE;
 }
@@ -1124,12 +1124,14 @@ kii_bool_t init_kii_thing_if_with_onboarded_thing(
         return KII_FALSE;
     }
 
+    kii_thing_if->state = KII_THING_IF_STATE_ONBOARDED;
+
     return KII_TRUE;
 }
 
 kii_bool_t start(kii_thing_if_t* kii_thing_if)
 {
-    if (kii_thing_if == NULL) {
+    if (kii_thing_if->state != KII_THING_IF_STATE_ONBOARDED) {
         return KII_FALSE;
     }
 

--- a/kii_thing_if.h
+++ b/kii_thing_if.h
@@ -11,6 +11,16 @@ extern "C" {
 
 #define KII_THING_IF_TASK_NAME_STATUS_UPDATE "status_update_task"
 
+/** States of kii_thing_if_t instance. */
+typedef enum kii_thing_if_state_t {
+    /** A kii_thing_if_t instance is initialized. */
+    KII_THING_IF_STATE_INITIALIZED,
+    /** A kii_thing_if_t instance is onboarded. */
+    KII_THING_IF_STATE_ONBOARDED,
+    /** A kii_thing_if_t instance is started. */
+    KII_THING_IF_STATE_STARTED
+} kii_thing_if_state_t;
+
 /** Error reasons of thing-if ThingSDK. */
 typedef enum kii_thing_if_error_reason_t {
     /** kii_thing_if_t instance is not onbarded. Please onboard first. */
@@ -270,12 +280,11 @@ typedef struct kii_thing_if_t {
     KII_THING_IF_CUSTOM_PUSH_HANDLER custom_push_handler;
     /** Specify the period of updating state in seconds. */
     int state_update_period;
-
     /**
-     * Represent kii_thing_if_t is started or not. Application must
+     * Represent state of kii_thing_if_t instance. Application must
      * not change this value.
      */
-    kii_bool_t is_started;
+    kii_thing_if_state_t state;
 } kii_thing_if_t;
 
 /** Initialize kii_thing_if_t object.
@@ -284,6 +293,9 @@ typedef struct kii_thing_if_t {
  * onboard_with_vendor_thing_id(kii_thing_if_t*, const char*, const char*,
  * const char*, const char*) or onboard_with_thing_id(kii_thing_if_t*,
  * const char*, const char*) to onboard from thing.
+ *
+ * After this functions succeeded, kii_thing_if_t::state becomes
+ * ::KII_THING_IF_STATE_INITIALIZED.
  *
  * @param [in] kii_thing_if kii_thing_if_t object to be initialized.
  * @param [in] app_id the input of Application ID
@@ -319,6 +331,9 @@ kii_bool_t init_kii_thing_if(
  * - ::onboard_with_thing_id
  * - ::init_kii_thing_if_with_onboarded_thing
  *
+ * After this functions succeeded, kii_thing_if_t::state becomes
+ * ::KII_THING_IF_STATE_STARTED.
+ *
  * @param [in] kii_thing_if_t This SDK instance.
  * @return KII_TRUE when succeeded, KII_FALSE when failed.
  */
@@ -327,6 +342,10 @@ kii_bool_t start(kii_thing_if_t* kii_thing_if);
 /** Onboard to Thing_If Cloud with specified vendor thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
  * used to call api.
+ *
+ * After this functions succeeded, kii_thing_if_t::state becomes
+ * ::KII_THING_IF_STATE_ONBOARDED.
+ *
  * @param [inout] kii_thing_if This SDK instance.
  * @param [in] vendor_thing_id Vendor thing id given by thing
  * vendor. Must not be NULL and empty string.
@@ -368,6 +387,10 @@ kii_bool_t onboard_with_vendor_thing_id(
 /** Onboard to Thing_If Cloud with specified thing ID.
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
  * used to call api.
+ *
+ * After this functions succeeded, kii_thing_if_t::state becomes
+ * ::KII_THING_IF_STATE_ONBOARDED.
+ *
  * @param [inout] kii_thing_if This SDK instance.
  * @param [in] thing_id thing ID issued by Kii Cloud. Must not be NULL
  * and empty string.
@@ -417,6 +440,9 @@ kii_bool_t onboard_with_thing_id(
  *
  * kii_thing_if_t#command_handler and kii_thing_if_t#state_updater instances are
  * used to call api.
+ *
+ * After this functions succeeded, kii_thing_if_t::state becomes
+ * ::KII_THING_IF_STATE_ONBOARDED.
  *
  * @param [in] app_id the input of Application ID
  * @param [in] app_key the input of Application Key


### PR DESCRIPTION
To distinguish `kii_thing_if_t` instance already started state updater and command handler or not, I introduced `kii_thing_if_t#is_started`. However, we want to distinguish `kii_thing_if_t` is already onboarded or not.

As a result, I replace `is_started` to `state` and introduce `kii_thing_if_state_t` enum.

Related PR: #81 